### PR TITLE
feat: DLQ alarm + error reply on handler failure (#15)

### DIFF
--- a/src/packages/app-framework/src/webhook/handlers/commentHandler.handler.ts
+++ b/src/packages/app-framework/src/webhook/handlers/commentHandler.handler.ts
@@ -103,60 +103,76 @@ export const handler = async (event: CommentEvent): Promise<void> => {
     return;
   }
 
-  const authResult = await authorizeUser({
-    senderLogin: detail.sender.login,
-    senderId: detail.sender.id,
-    repoFullName: detail.repository.full_name,
-    installationToken,
-    orgName,
-  });
+  try {
+    const authResult = await authorizeUser({
+      senderLogin: detail.sender.login,
+      senderId: detail.sender.id,
+      repoFullName: detail.repository.full_name,
+      installationToken,
+      orgName,
+    });
 
-  if (!authResult.authorized) {
-    if (authResult.needsAuth) {
-      const authUrl = process.env.AUTH_LOGIN_URL || '';
-      await postComment({
-        token: installationToken,
-        owner,
-        repo,
-        issueNumber: detail.payload.issue.number,
-        body: `@${detail.sender.login} I need you to [authorize this app](${authUrl}?repo=${detail.repository.full_name}&issue=${detail.payload.issue.number}) before I can act on your behalf.`,
-      });
-    } else {
-      await postComment({
-        token: installationToken,
-        owner,
-        repo,
-        issueNumber: detail.payload.issue.number,
-        body: `@${detail.sender.login} ${authResult.reason}`,
-      });
+    if (!authResult.authorized) {
+      if (authResult.needsAuth) {
+        const authUrl = process.env.AUTH_LOGIN_URL || '';
+        await postComment({
+          token: installationToken,
+          owner,
+          repo,
+          issueNumber: detail.payload.issue.number,
+          body: `@${detail.sender.login} I need you to [authorize this app](${authUrl}?repo=${detail.repository.full_name}&issue=${detail.payload.issue.number}) before I can act on your behalf.`,
+        });
+      } else {
+        await postComment({
+          token: installationToken,
+          owner,
+          repo,
+          issueNumber: detail.payload.issue.number,
+          body: `@${detail.sender.login} ${authResult.reason}`,
+        });
+      }
+      return;
     }
-    return;
-  }
 
-  const command = commentBody
-    .slice(commentBody.indexOf(trigger) + trigger.length)
-    .trim();
-  const [cmdName, ...cmdArgs] = command.split(' ');
+    const command = commentBody
+      .slice(commentBody.indexOf(trigger) + trigger.length)
+      .trim();
+    const [cmdName, ...cmdArgs] = command.split(' ');
 
-  const ctx: CommandContext = {
-    args: cmdArgs.join(' '),
-    token: authResult.userToken!.accessToken,
-    owner,
-    repo,
-    issueNumber: detail.payload.issue.number,
-    sender: detail.sender.login,
-  };
-
-  const commandHandler = getCommandHandler(cmdName) || getDefaultHandler();
-  await commandHandler(ctx);
-
-  console.log(
-    JSON.stringify({
-      handler: 'commentHandler',
-      deliveryId: detail.delivery_id,
-      sender: detail.sender.login,
-      command: cmdName,
+    const ctx: CommandContext = {
       args: cmdArgs.join(' '),
-    }),
-  );
+      token: authResult.userToken!.accessToken,
+      owner,
+      repo,
+      issueNumber: detail.payload.issue.number,
+      sender: detail.sender.login,
+    };
+
+    const commandHandler = getCommandHandler(cmdName) || getDefaultHandler();
+    await commandHandler(ctx);
+
+    console.log(
+      JSON.stringify({
+        handler: 'commentHandler',
+        deliveryId: detail.delivery_id,
+        sender: detail.sender.login,
+        command: cmdName,
+        args: cmdArgs.join(' '),
+      }),
+    );
+  } catch (error) {
+    console.error('Handler error', { deliveryId: detail.delivery_id, error });
+    try {
+      await postComment({
+        token: installationToken,
+        owner,
+        repo,
+        issueNumber: detail.payload.issue.number,
+        body: `@${detail.sender.login} Sorry, I encountered an error processing your request. The team has been notified.`,
+      });
+    } catch (replyError) {
+      console.error('Failed to post error reply', replyError);
+    }
+    throw error;
+  }
 };

--- a/src/packages/app-framework/src/webhook/index.ts
+++ b/src/packages/app-framework/src/webhook/index.ts
@@ -403,12 +403,26 @@ export class WebhookIngestion extends Construct {
       treatMissingData: TreatMissingData.NOT_BREACHING,
     });
 
+    const dlqAlarm = new Alarm(this, 'DLQDepthAlarm', {
+      alarmName: 'ai3-mvp-dlq-not-empty',
+      alarmDescription:
+        'DLQ has messages - handler failures detected',
+      metric: alert.dlq.metricApproximateNumberOfMessagesVisible({
+        period: Duration.minutes(5),
+      }),
+      threshold: 1,
+      evaluationPeriods: 1,
+      comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+      treatMissingData: TreatMissingData.NOT_BREACHING,
+    });
+
     if (props.alertEmail) {
       const alertTopic = new Topic(this, 'AlertTopic', {
         topicName: 'ai3-mvp-webhook-alerts',
       });
       alertTopic.addSubscription(new EmailSubscription(props.alertEmail));
       oversizedAlarm.addAlarmAction(new SnsAction(alertTopic));
+      dlqAlarm.addAlarmAction(new SnsAction(alertTopic));
     }
 
     Tags.of(this).add('ai3-mvp', 'WebhookIngestion');

--- a/src/packages/app-framework/src/webhook/index.ts
+++ b/src/packages/app-framework/src/webhook/index.ts
@@ -6,7 +6,10 @@ import {
 } from 'aws-cdk-lib/aws-apigateway';
 import {
   Alarm,
+  AlarmWidget,
   ComparisonOperator,
+  Dashboard,
+  GraphWidget,
   Metric,
   TreatMissingData,
 } from 'aws-cdk-lib/aws-cloudwatch';
@@ -424,6 +427,58 @@ export class WebhookIngestion extends Construct {
       oversizedAlarm.addAlarmAction(new SnsAction(alertTopic));
       dlqAlarm.addAlarmAction(new SnsAction(alertTopic));
     }
+
+    const dashboard = new Dashboard(this, 'OperationsDashboard', {
+      dashboardName: 'ai3-mvp-platform',
+    });
+
+    dashboard.addWidgets(
+      new GraphWidget({
+        title: 'Webhook Ingestion Rate',
+        left: [receiver.lambdaHandler.metricInvocations({ period: Duration.minutes(5) })],
+        width: 8,
+        height: 6,
+      }),
+      new GraphWidget({
+        title: 'Handler Errors',
+        left: [
+          receiver.lambdaHandler.metricErrors({ period: Duration.minutes(5), label: 'Receiver' }),
+          stub.lambdaHandler.metricErrors({ period: Duration.minutes(5), label: 'Stub' }),
+        ],
+        width: 8,
+        height: 6,
+      }),
+      new GraphWidget({
+        title: 'DLQ Depth',
+        left: [alert.dlq.metricApproximateNumberOfMessagesVisible({ period: Duration.minutes(5) })],
+        width: 8,
+        height: 6,
+      }),
+    );
+
+    dashboard.addWidgets(
+      new GraphWidget({
+        title: 'API Gateway 4XX / 5XX',
+        left: [
+          new Metric({ namespace: 'AWS/ApiGateway', metricName: '4XXError', dimensionsMap: { ApiName: 'ai3-mvp-webhook' }, period: Duration.minutes(5), statistic: 'Sum', label: '4XX' }),
+          new Metric({ namespace: 'AWS/ApiGateway', metricName: '5XXError', dimensionsMap: { ApiName: 'ai3-mvp-webhook' }, period: Duration.minutes(5), statistic: 'Sum', label: '5XX' }),
+        ],
+        width: 8,
+        height: 6,
+      }),
+      new AlarmWidget({
+        title: 'Alarm: Oversized Payload',
+        alarm: oversizedAlarm,
+        width: 8,
+        height: 6,
+      }),
+      new AlarmWidget({
+        title: 'Alarm: DLQ Not Empty',
+        alarm: dlqAlarm,
+        width: 8,
+        height: 6,
+      }),
+    );
 
     Tags.of(this).add('ai3-mvp', 'WebhookIngestion');
   }


### PR DESCRIPTION
## Issue
Closes #15

## Changes
- CloudWatch alarm on DLQ depth (fires when messages > 0, wired to SNS if alertEmail configured)
- Comment handler try/catch: replies with error message using installation token before re-throwing to DLQ
- User now sees "Sorry, I encountered an error" instead of silence

## Test plan
- [x] TypeScript compiles cleanly
- [x] 3 comment handler tests pass
- [ ] Deploy and verify alarm exists
- [ ] (Optional) Trigger a failure to see error reply

🤖 Generated with [Claude Code](https://claude.com/claude-code)