### PR TITLE
feat: dynamic custom metrics with event-driven dimensions (#17)

### DIFF
--- a/src/packages/app-framework/src/webhook/handlers/checkRunHandler.handler.ts
+++ b/src/packages/app-framework/src/webhook/handlers/checkRunHandler.handler.ts
@@ -1,3 +1,5 @@
+import { publishEventProcessed } from '../utils/metrics';
+
 // prettier-ignore
 interface EventDetail {
   'detail-type': string;
@@ -11,6 +13,12 @@ interface EventDetail {
 }
 
 export const handler = async (event: EventDetail): Promise<void> => {
+  publishEventProcessed({
+    appId: (event.detail as any).installation?.app_id,
+    orgName: (event.detail as any).organization?.login,
+    eventType: event['detail-type'],
+    handlerName: 'checkRunHandler',
+  });
   console.log(
     JSON.stringify({
       handler: 'checkRunHandler',

--- a/src/packages/app-framework/src/webhook/handlers/checkRunHandler.handler.ts
+++ b/src/packages/app-framework/src/webhook/handlers/checkRunHandler.handler.ts
@@ -14,7 +14,7 @@ interface EventDetail {
 
 export const handler = async (event: EventDetail): Promise<void> => {
   publishEventProcessed({
-    appId: (event.detail as any).installation?.app_id,
+    appId: (event.detail as any).installation?.id,
     orgName: (event.detail as any).organization?.login,
     eventType: event['detail-type'],
     handlerName: 'checkRunHandler',

--- a/src/packages/app-framework/src/webhook/handlers/commentHandler.handler.ts
+++ b/src/packages/app-framework/src/webhook/handlers/commentHandler.handler.ts
@@ -97,7 +97,7 @@ export const handler = async (event: CommentEvent): Promise<void> => {
   const orgName = process.env.ORG_NAME || owner;
 
   const metricCtx: EventMetricContext = {
-    appId: detail.installation?.app_id,
+    appId: process.env.APP_ID || detail.installation?.id,
     orgName: detail.organization?.login || owner,
     eventType: event['detail-type'],
     handlerName: 'commentHandler',

--- a/src/packages/app-framework/src/webhook/handlers/commentHandler.handler.ts
+++ b/src/packages/app-framework/src/webhook/handlers/commentHandler.handler.ts
@@ -5,6 +5,7 @@ import {
 } from './commands';
 import { authorizeUser } from '../auth/authorizeUser';
 import { postComment } from '../orchestration/reportComment';
+import { publishEventProcessed, publishCommandExecuted, publishAuthResult, publishError, EventMetricContext } from '../utils/metrics';
 
 const BOT_TRIGGERS = ['@ai3-mvp', '/ai3-mvp'];
 
@@ -16,7 +17,8 @@ interface CommentEvent {
     action: string;
     sender: { login: string; id: number };
     repository: { full_name: string };
-    installation?: { id: number };
+    installation?: { id: number; app_id: number };
+    organization?: { login: string };
     payload: {
       comment: { body: string };
       issue: { number: number };
@@ -94,6 +96,14 @@ export const handler = async (event: CommentEvent): Promise<void> => {
   const [owner, repo] = detail.repository.full_name.split('/');
   const orgName = process.env.ORG_NAME || owner;
 
+  const metricCtx: EventMetricContext = {
+    appId: detail.installation?.app_id,
+    orgName: detail.organization?.login || owner,
+    eventType: event['detail-type'],
+    handlerName: 'commentHandler',
+  };
+  publishEventProcessed(metricCtx);
+
   const installationToken = await getInstallationToken();
 
   if (!installationToken) {
@@ -113,6 +123,7 @@ export const handler = async (event: CommentEvent): Promise<void> => {
     });
 
     if (!authResult.authorized) {
+      publishAuthResult(metricCtx, false);
       if (authResult.needsAuth) {
         const authUrl = process.env.AUTH_LOGIN_URL || '';
         await postComment({
@@ -134,6 +145,8 @@ export const handler = async (event: CommentEvent): Promise<void> => {
       return;
     }
 
+    publishAuthResult(metricCtx, true);
+
     const command = commentBody
       .slice(commentBody.indexOf(trigger) + trigger.length)
       .trim();
@@ -150,6 +163,7 @@ export const handler = async (event: CommentEvent): Promise<void> => {
 
     const commandHandler = getCommandHandler(cmdName) || getDefaultHandler();
     await commandHandler(ctx);
+    publishCommandExecuted(metricCtx, cmdName);
 
     console.log(
       JSON.stringify({
@@ -161,6 +175,7 @@ export const handler = async (event: CommentEvent): Promise<void> => {
       }),
     );
   } catch (error) {
+    publishError(metricCtx);
     console.error('Handler error', { deliveryId: detail.delivery_id, error });
     try {
       await postComment({

--- a/src/packages/app-framework/src/webhook/handlers/deploymentHandler.handler.ts
+++ b/src/packages/app-framework/src/webhook/handlers/deploymentHandler.handler.ts
@@ -1,3 +1,5 @@
+import { publishEventProcessed } from '../utils/metrics';
+
 // prettier-ignore
 interface EventDetail {
   'detail-type': string;
@@ -11,6 +13,12 @@ interface EventDetail {
 }
 
 export const handler = async (event: EventDetail): Promise<void> => {
+  publishEventProcessed({
+    appId: (event.detail as any).installation?.app_id,
+    orgName: (event.detail as any).organization?.login,
+    eventType: event['detail-type'],
+    handlerName: 'deploymentHandler',
+  });
   console.log(
     JSON.stringify({
       handler: 'deploymentHandler',

--- a/src/packages/app-framework/src/webhook/handlers/deploymentHandler.handler.ts
+++ b/src/packages/app-framework/src/webhook/handlers/deploymentHandler.handler.ts
@@ -14,7 +14,7 @@ interface EventDetail {
 
 export const handler = async (event: EventDetail): Promise<void> => {
   publishEventProcessed({
-    appId: (event.detail as any).installation?.app_id,
+    appId: (event.detail as any).installation?.id,
     orgName: (event.detail as any).organization?.login,
     eventType: event['detail-type'],
     handlerName: 'deploymentHandler',

--- a/src/packages/app-framework/src/webhook/handlers/discussionHandler.handler.ts
+++ b/src/packages/app-framework/src/webhook/handlers/discussionHandler.handler.ts
@@ -1,3 +1,5 @@
+import { publishEventProcessed } from '../utils/metrics';
+
 // prettier-ignore
 interface EventDetail {
   'detail-type': string;
@@ -11,6 +13,12 @@ interface EventDetail {
 }
 
 export const handler = async (event: EventDetail): Promise<void> => {
+  publishEventProcessed({
+    appId: (event.detail as any).installation?.app_id,
+    orgName: (event.detail as any).organization?.login,
+    eventType: event['detail-type'],
+    handlerName: 'discussionHandler',
+  });
   console.log(
     JSON.stringify({
       handler: 'discussionHandler',

--- a/src/packages/app-framework/src/webhook/handlers/discussionHandler.handler.ts
+++ b/src/packages/app-framework/src/webhook/handlers/discussionHandler.handler.ts
@@ -14,7 +14,7 @@ interface EventDetail {
 
 export const handler = async (event: EventDetail): Promise<void> => {
   publishEventProcessed({
-    appId: (event.detail as any).installation?.app_id,
+    appId: (event.detail as any).installation?.id,
     orgName: (event.detail as any).organization?.login,
     eventType: event['detail-type'],
     handlerName: 'discussionHandler',

--- a/src/packages/app-framework/src/webhook/handlers/prHandler.handler.ts
+++ b/src/packages/app-framework/src/webhook/handlers/prHandler.handler.ts
@@ -1,3 +1,5 @@
+import { publishEventProcessed } from '../utils/metrics';
+
 // prettier-ignore
 interface EventDetail {
   'detail-type': string;
@@ -11,6 +13,12 @@ interface EventDetail {
 }
 
 export const handler = async (event: EventDetail): Promise<void> => {
+  publishEventProcessed({
+    appId: (event.detail as any).installation?.app_id,
+    orgName: (event.detail as any).organization?.login,
+    eventType: event['detail-type'],
+    handlerName: 'prHandler',
+  });
   console.log(
     JSON.stringify({
       handler: 'prHandler',

--- a/src/packages/app-framework/src/webhook/handlers/prHandler.handler.ts
+++ b/src/packages/app-framework/src/webhook/handlers/prHandler.handler.ts
@@ -14,7 +14,7 @@ interface EventDetail {
 
 export const handler = async (event: EventDetail): Promise<void> => {
   publishEventProcessed({
-    appId: (event.detail as any).installation?.app_id,
+    appId: (event.detail as any).installation?.id,
     orgName: (event.detail as any).organization?.login,
     eventType: event['detail-type'],
     handlerName: 'prHandler',

--- a/src/packages/app-framework/src/webhook/handlers/pushHandler.handler.ts
+++ b/src/packages/app-framework/src/webhook/handlers/pushHandler.handler.ts
@@ -14,7 +14,7 @@ interface EventDetail {
 
 export const handler = async (event: EventDetail): Promise<void> => {
   publishEventProcessed({
-    appId: (event.detail as any).installation?.app_id,
+    appId: (event.detail as any).installation?.id,
     orgName: (event.detail as any).organization?.login,
     eventType: event['detail-type'],
     handlerName: 'pushHandler',

--- a/src/packages/app-framework/src/webhook/handlers/pushHandler.handler.ts
+++ b/src/packages/app-framework/src/webhook/handlers/pushHandler.handler.ts
@@ -1,3 +1,5 @@
+import { publishEventProcessed } from '../utils/metrics';
+
 // prettier-ignore
 interface EventDetail {
   'detail-type': string;
@@ -11,6 +13,12 @@ interface EventDetail {
 }
 
 export const handler = async (event: EventDetail): Promise<void> => {
+  publishEventProcessed({
+    appId: (event.detail as any).installation?.app_id,
+    orgName: (event.detail as any).organization?.login,
+    eventType: event['detail-type'],
+    handlerName: 'pushHandler',
+  });
   console.log(
     JSON.stringify({
       handler: 'pushHandler',

--- a/src/packages/app-framework/src/webhook/handlers/stubHandler.handler.ts
+++ b/src/packages/app-framework/src/webhook/handlers/stubHandler.handler.ts
@@ -17,7 +17,7 @@ export const handler = async (
   event: GitHubEventBridgeEvent,
 ): Promise<{ received: boolean }> => {
   publishEventProcessed({
-    appId: (event.detail as any).installation?.app_id,
+    appId: (event.detail as any).installation?.id,
     orgName: (event.detail as any).organization?.login,
     eventType: event['detail-type'],
     handlerName: 'stubHandler',

--- a/src/packages/app-framework/src/webhook/handlers/stubHandler.handler.ts
+++ b/src/packages/app-framework/src/webhook/handlers/stubHandler.handler.ts
@@ -1,3 +1,5 @@
+import { publishEventProcessed } from '../utils/metrics';
+
 // prettier-ignore
 interface GitHubEventBridgeEvent {
   'source': string;
@@ -14,6 +16,12 @@ interface GitHubEventBridgeEvent {
 export const handler = async (
   event: GitHubEventBridgeEvent,
 ): Promise<{ received: boolean }> => {
+  publishEventProcessed({
+    appId: (event.detail as any).installation?.app_id,
+    orgName: (event.detail as any).organization?.login,
+    eventType: event['detail-type'],
+    handlerName: 'stubHandler',
+  });
   console.log(
     JSON.stringify({
       eventType: event['detail-type'],

--- a/src/packages/app-framework/src/webhook/index.ts
+++ b/src/packages/app-framework/src/webhook/index.ts
@@ -437,7 +437,7 @@ export class WebhookIngestion extends Construct {
       new GraphWidget({
         title: 'Events Processed by Handler',
         left: [new MathExpression({
-          expression: "SEARCH('{GitHubAppPlatform,AppId,OrgName,EventType,HandlerName,service} MetricName=\"EventProcessed\"', 'Sum')",
+          expression: "SEARCH('{GitHubAppPlatform,AppId,EventType,HandlerName,OrgName,service} MetricName=\"EventProcessed\"', 'Sum')",
           period: Duration.minutes(5),
         })],
         width: 8,
@@ -446,7 +446,7 @@ export class WebhookIngestion extends Construct {
       new GraphWidget({
         title: 'Commands Executed',
         left: [new MathExpression({
-          expression: "SEARCH('{GitHubAppPlatform,AppId,OrgName,HandlerName,Command,service} MetricName=\"CommandExecuted\"', 'Sum')",
+          expression: "SEARCH('{GitHubAppPlatform,AppId,Command,HandlerName,OrgName,service} MetricName=\"CommandExecuted\"', 'Sum')",
           period: Duration.minutes(5),
         })],
         width: 8,
@@ -456,12 +456,12 @@ export class WebhookIngestion extends Construct {
         title: 'Auth Results',
         left: [
           new MathExpression({
-            expression: "SEARCH('{GitHubAppPlatform,AppId,OrgName,HandlerName,service} MetricName=\"AuthSuccess\"', 'Sum')",
+            expression: "SEARCH('{GitHubAppPlatform,AppId,HandlerName,OrgName,service} MetricName=\"AuthSuccess\"', 'Sum')",
             period: Duration.minutes(5),
             label: 'Success',
           }),
           new MathExpression({
-            expression: "SEARCH('{GitHubAppPlatform,AppId,OrgName,HandlerName,service} MetricName=\"AuthFailed\"', 'Sum')",
+            expression: "SEARCH('{GitHubAppPlatform,AppId,HandlerName,OrgName,service} MetricName=\"AuthFailed\"', 'Sum')",
             period: Duration.minutes(5),
             label: 'Failed',
           }),
@@ -475,7 +475,7 @@ export class WebhookIngestion extends Construct {
       new GraphWidget({
         title: 'Errors by Handler',
         left: [new MathExpression({
-          expression: "SEARCH('{GitHubAppPlatform,AppId,OrgName,HandlerName,service} MetricName=\"ErrorOccurred\"', 'Sum')",
+          expression: "SEARCH('{GitHubAppPlatform,AppId,HandlerName,OrgName,service} MetricName=\"ErrorOccurred\"', 'Sum')",
           period: Duration.minutes(5),
         })],
         width: 8,

--- a/src/packages/app-framework/src/webhook/index.ts
+++ b/src/packages/app-framework/src/webhook/index.ts
@@ -437,7 +437,7 @@ export class WebhookIngestion extends Construct {
       new GraphWidget({
         title: 'Events Processed by Handler',
         left: [new MathExpression({
-          expression: "SEARCH('{GitHubAppPlatform,AppId,OrgName,EventType,HandlerName} MetricName=\"EventProcessed\"', 'Sum')",
+          expression: "SEARCH('{GitHubAppPlatform,AppId,OrgName,EventType,HandlerName,service} MetricName=\"EventProcessed\"', 'Sum')",
           period: Duration.minutes(5),
         })],
         width: 8,
@@ -446,7 +446,7 @@ export class WebhookIngestion extends Construct {
       new GraphWidget({
         title: 'Commands Executed',
         left: [new MathExpression({
-          expression: "SEARCH('{GitHubAppPlatform,AppId,OrgName,HandlerName,Command} MetricName=\"CommandExecuted\"', 'Sum')",
+          expression: "SEARCH('{GitHubAppPlatform,AppId,OrgName,HandlerName,Command,service} MetricName=\"CommandExecuted\"', 'Sum')",
           period: Duration.minutes(5),
         })],
         width: 8,
@@ -456,12 +456,12 @@ export class WebhookIngestion extends Construct {
         title: 'Auth Results',
         left: [
           new MathExpression({
-            expression: "SEARCH('{GitHubAppPlatform,AppId,OrgName,HandlerName} MetricName=\"AuthSuccess\"', 'Sum')",
+            expression: "SEARCH('{GitHubAppPlatform,AppId,OrgName,HandlerName,service} MetricName=\"AuthSuccess\"', 'Sum')",
             period: Duration.minutes(5),
             label: 'Success',
           }),
           new MathExpression({
-            expression: "SEARCH('{GitHubAppPlatform,AppId,OrgName,HandlerName} MetricName=\"AuthFailed\"', 'Sum')",
+            expression: "SEARCH('{GitHubAppPlatform,AppId,OrgName,HandlerName,service} MetricName=\"AuthFailed\"', 'Sum')",
             period: Duration.minutes(5),
             label: 'Failed',
           }),
@@ -475,7 +475,7 @@ export class WebhookIngestion extends Construct {
       new GraphWidget({
         title: 'Errors by Handler',
         left: [new MathExpression({
-          expression: "SEARCH('{GitHubAppPlatform,AppId,OrgName,HandlerName} MetricName=\"ErrorOccurred\"', 'Sum')",
+          expression: "SEARCH('{GitHubAppPlatform,AppId,OrgName,HandlerName,service} MetricName=\"ErrorOccurred\"', 'Sum')",
           period: Duration.minutes(5),
         })],
         width: 8,

--- a/src/packages/app-framework/src/webhook/index.ts
+++ b/src/packages/app-framework/src/webhook/index.ts
@@ -438,6 +438,7 @@ export class WebhookIngestion extends Construct {
         title: 'Events Processed by Handler',
         left: [new MathExpression({
           expression: "SEARCH('{GitHubAppPlatform,AppId,EventType,HandlerName,OrgName,service} MetricName=\"EventProcessed\"', 'Sum', 300)",
+          label: '',
         })],
         width: 8,
         height: 6,
@@ -446,6 +447,7 @@ export class WebhookIngestion extends Construct {
         title: 'Commands Executed',
         left: [new MathExpression({
           expression: "SEARCH('{GitHubAppPlatform,AppId,Command,HandlerName,OrgName,service} MetricName=\"CommandExecuted\"', 'Sum', 300)",
+          label: '',
         })],
         width: 8,
         height: 6,
@@ -455,11 +457,11 @@ export class WebhookIngestion extends Construct {
         left: [
           new MathExpression({
             expression: "SEARCH('{GitHubAppPlatform,AppId,HandlerName,OrgName,service} MetricName=\"AuthSuccess\"', 'Sum', 300)",
-            label: 'Success',
+            label: 'Auth Success',
           }),
           new MathExpression({
             expression: "SEARCH('{GitHubAppPlatform,AppId,HandlerName,OrgName,service} MetricName=\"AuthFailed\"', 'Sum', 300)",
-            label: 'Failed',
+            label: 'Auth Failed',
           }),
         ],
         width: 8,
@@ -472,6 +474,7 @@ export class WebhookIngestion extends Construct {
         title: 'Errors by Handler',
         left: [new MathExpression({
           expression: "SEARCH('{GitHubAppPlatform,AppId,HandlerName,OrgName,service} MetricName=\"ErrorOccurred\"', 'Sum', 300)",
+          label: '',
         })],
         width: 8,
         height: 6,

--- a/src/packages/app-framework/src/webhook/index.ts
+++ b/src/packages/app-framework/src/webhook/index.ts
@@ -10,6 +10,7 @@ import {
   ComparisonOperator,
   Dashboard,
   GraphWidget,
+  MathExpression,
   Metric,
   TreatMissingData,
 } from 'aws-cdk-lib/aws-cloudwatch';
@@ -434,17 +435,49 @@ export class WebhookIngestion extends Construct {
 
     dashboard.addWidgets(
       new GraphWidget({
-        title: 'Webhook Ingestion Rate',
-        left: [receiver.lambdaHandler.metricInvocations({ period: Duration.minutes(5) })],
+        title: 'Events Processed by Handler',
+        left: [new MathExpression({
+          expression: "SEARCH('{GitHubAppPlatform,AppId,OrgName,EventType,HandlerName} MetricName=\"EventProcessed\"', 'Sum')",
+          period: Duration.minutes(5),
+        })],
         width: 8,
         height: 6,
       }),
       new GraphWidget({
-        title: 'Handler Errors',
+        title: 'Commands Executed',
+        left: [new MathExpression({
+          expression: "SEARCH('{GitHubAppPlatform,AppId,OrgName,HandlerName,Command} MetricName=\"CommandExecuted\"', 'Sum')",
+          period: Duration.minutes(5),
+        })],
+        width: 8,
+        height: 6,
+      }),
+      new GraphWidget({
+        title: 'Auth Results',
         left: [
-          receiver.lambdaHandler.metricErrors({ period: Duration.minutes(5), label: 'Receiver' }),
-          stub.lambdaHandler.metricErrors({ period: Duration.minutes(5), label: 'Stub' }),
+          new MathExpression({
+            expression: "SEARCH('{GitHubAppPlatform,AppId,OrgName,HandlerName} MetricName=\"AuthSuccess\"', 'Sum')",
+            period: Duration.minutes(5),
+            label: 'Success',
+          }),
+          new MathExpression({
+            expression: "SEARCH('{GitHubAppPlatform,AppId,OrgName,HandlerName} MetricName=\"AuthFailed\"', 'Sum')",
+            period: Duration.minutes(5),
+            label: 'Failed',
+          }),
         ],
+        width: 8,
+        height: 6,
+      }),
+    );
+
+    dashboard.addWidgets(
+      new GraphWidget({
+        title: 'Errors by Handler',
+        left: [new MathExpression({
+          expression: "SEARCH('{GitHubAppPlatform,AppId,OrgName,HandlerName} MetricName=\"ErrorOccurred\"', 'Sum')",
+          period: Duration.minutes(5),
+        })],
         width: 8,
         height: 6,
       }),
@@ -454,9 +487,6 @@ export class WebhookIngestion extends Construct {
         width: 8,
         height: 6,
       }),
-    );
-
-    dashboard.addWidgets(
       new GraphWidget({
         title: 'API Gateway 4XX / 5XX',
         left: [
@@ -466,16 +496,19 @@ export class WebhookIngestion extends Construct {
         width: 8,
         height: 6,
       }),
+    );
+
+    dashboard.addWidgets(
       new AlarmWidget({
         title: 'Alarm: Oversized Payload',
         alarm: oversizedAlarm,
-        width: 8,
+        width: 12,
         height: 6,
       }),
       new AlarmWidget({
         title: 'Alarm: DLQ Not Empty',
         alarm: dlqAlarm,
-        width: 8,
+        width: 12,
         height: 6,
       }),
     );

--- a/src/packages/app-framework/src/webhook/index.ts
+++ b/src/packages/app-framework/src/webhook/index.ts
@@ -437,8 +437,7 @@ export class WebhookIngestion extends Construct {
       new GraphWidget({
         title: 'Events Processed by Handler',
         left: [new MathExpression({
-          expression: "SEARCH('{GitHubAppPlatform,AppId,EventType,HandlerName,OrgName,service} MetricName=\"EventProcessed\"', 'Sum')",
-          period: Duration.minutes(5),
+          expression: "SEARCH('{GitHubAppPlatform,AppId,EventType,HandlerName,OrgName,service} MetricName=\"EventProcessed\"', 'Sum', 300)",
         })],
         width: 8,
         height: 6,
@@ -446,8 +445,7 @@ export class WebhookIngestion extends Construct {
       new GraphWidget({
         title: 'Commands Executed',
         left: [new MathExpression({
-          expression: "SEARCH('{GitHubAppPlatform,AppId,Command,HandlerName,OrgName,service} MetricName=\"CommandExecuted\"', 'Sum')",
-          period: Duration.minutes(5),
+          expression: "SEARCH('{GitHubAppPlatform,AppId,Command,HandlerName,OrgName,service} MetricName=\"CommandExecuted\"', 'Sum', 300)",
         })],
         width: 8,
         height: 6,
@@ -456,13 +454,11 @@ export class WebhookIngestion extends Construct {
         title: 'Auth Results',
         left: [
           new MathExpression({
-            expression: "SEARCH('{GitHubAppPlatform,AppId,HandlerName,OrgName,service} MetricName=\"AuthSuccess\"', 'Sum')",
-            period: Duration.minutes(5),
+            expression: "SEARCH('{GitHubAppPlatform,AppId,HandlerName,OrgName,service} MetricName=\"AuthSuccess\"', 'Sum', 300)",
             label: 'Success',
           }),
           new MathExpression({
-            expression: "SEARCH('{GitHubAppPlatform,AppId,HandlerName,OrgName,service} MetricName=\"AuthFailed\"', 'Sum')",
-            period: Duration.minutes(5),
+            expression: "SEARCH('{GitHubAppPlatform,AppId,HandlerName,OrgName,service} MetricName=\"AuthFailed\"', 'Sum', 300)",
             label: 'Failed',
           }),
         ],
@@ -475,8 +471,7 @@ export class WebhookIngestion extends Construct {
       new GraphWidget({
         title: 'Errors by Handler',
         left: [new MathExpression({
-          expression: "SEARCH('{GitHubAppPlatform,AppId,HandlerName,OrgName,service} MetricName=\"ErrorOccurred\"', 'Sum')",
-          period: Duration.minutes(5),
+          expression: "SEARCH('{GitHubAppPlatform,AppId,HandlerName,OrgName,service} MetricName=\"ErrorOccurred\"', 'Sum', 300)",
         })],
         width: 8,
         height: 6,

--- a/src/packages/app-framework/src/webhook/utils/metrics.ts
+++ b/src/packages/app-framework/src/webhook/utils/metrics.ts
@@ -1,0 +1,48 @@
+import { Metrics, MetricUnit } from '@aws-lambda-powertools/metrics';
+
+const metrics = new Metrics({
+  namespace: 'GitHubAppPlatform',
+  serviceName: 'webhook',
+});
+
+export interface EventMetricContext {
+  appId?: string | number;
+  orgName?: string;
+  eventType: string;
+  handlerName: string;
+}
+
+export function publishEventProcessed(ctx: EventMetricContext): void {
+  metrics.addDimension('AppId', String(ctx.appId || 'unknown'));
+  metrics.addDimension('OrgName', ctx.orgName || 'unknown');
+  metrics.addDimension('EventType', ctx.eventType);
+  metrics.addDimension('HandlerName', ctx.handlerName);
+  metrics.addMetric('EventProcessed', MetricUnit.Count, 1);
+  metrics.publishStoredMetrics();
+}
+
+export function publishCommandExecuted(ctx: EventMetricContext, command: string): void {
+  metrics.addDimension('AppId', String(ctx.appId || 'unknown'));
+  metrics.addDimension('OrgName', ctx.orgName || 'unknown');
+  metrics.addDimension('HandlerName', ctx.handlerName);
+  metrics.addDimension('Command', command);
+  metrics.addMetric('CommandExecuted', MetricUnit.Count, 1);
+  metrics.publishStoredMetrics();
+}
+
+export function publishAuthResult(ctx: EventMetricContext, success: boolean): void {
+  metrics.addDimension('AppId', String(ctx.appId || 'unknown'));
+  metrics.addDimension('OrgName', ctx.orgName || 'unknown');
+  metrics.addDimension('HandlerName', ctx.handlerName);
+  const metricName = success ? 'AuthSuccess' : 'AuthFailed';
+  metrics.addMetric(metricName, MetricUnit.Count, 1);
+  metrics.publishStoredMetrics();
+}
+
+export function publishError(ctx: EventMetricContext): void {
+  metrics.addDimension('AppId', String(ctx.appId || 'unknown'));
+  metrics.addDimension('OrgName', ctx.orgName || 'unknown');
+  metrics.addDimension('HandlerName', ctx.handlerName);
+  metrics.addMetric('ErrorOccurred', MetricUnit.Count, 1);
+  metrics.publishStoredMetrics();
+}


### PR DESCRIPTION
## Issue
Closes #17

## Changes
- New shared `utils/metrics.ts` with `GitHubAppPlatform` namespace
- Dimensions from event payload: AppId, OrgName, EventType, HandlerName
- All 7 handlers instrumented with `publishEventProcessed`
- Comment handler: `CommandExecuted`, `AuthSuccess`/`AuthFailed`, `ErrorOccurred`
- Dashboard updated with SEARCH expressions (auto-discovers new apps/orgs)

## Test plan
- [x] TypeScript compiles, 3 comment handler tests pass
- [ ] Deploy and trigger events
- [ ] Verify custom metrics appear in CloudWatch under `GitHubAppPlatform` namespace
- [ ] Dashboard shows SEARCH-based widgets

🤖 Generated with [Claude Code](https://claude.com/claude-code)