### PR TITLE
feat(ops-tools): device-flow-auth CLI command (#8)

### DIFF
--- a/docs/runbooks/user-authorization.md
+++ b/docs/runbooks/user-authorization.md
@@ -1,0 +1,102 @@
+# User Authorization Runbook
+
+## Overview
+
+Users must authorize the GitHub App before the bot can act on their behalf. Authorization creates a user-to-server OAuth token (`ghu_`) that is stored encrypted in the UserTokens DynamoDB table.
+
+## How Users Authorize
+
+### Via GitHub Comment (Production Flow)
+
+When a user mentions `@ai3-mvp` or `/ai3-mvp` on an issue/PR and hasn't authorized yet, the bot replies with an authorization link. The user clicks the link, authorizes on GitHub, and the callback Lambda stores the token.
+
+### Via Device Flow CLI (Admin/Testing)
+
+For headless environments (SSH, tmux) or initial setup:
+
+```bash
+cd src/packages/app-framework-ops-tools
+
+npx ts-node src/app-framework-cli.ts device-flow-auth \
+  --client-id <GITHUB_CLIENT_ID> \
+  --user-tokens-table <USER_TOKENS_TABLE_NAME> \
+  --kms-key-arn <TOKEN_ENCRYPTION_KEY_ARN>
+```
+
+The command will display a URL and code. Open the URL in any browser, enter the code, and authorize.
+
+#### Finding the Required Values
+
+**Client ID** — From the GitHub App settings page:
+```
+github.com/organizations/<org>/settings/apps/<app-name>
+```
+
+**UserTokens table name:**
+```bash
+AWS_PROFILE=<profile> aws resourcegroupstaggingapi get-resources \
+  --tag-filters Key=ai3-mvp,Values=WebhookIngestion \
+  --resource-type-filters dynamodb:table \
+  --region us-east-1 \
+  --query 'ResourceTagMappingList[*].ResourceARN' --output text \
+  | tr '\t' '\n' | grep UserTokens | sed 's|.*/||'
+```
+
+**KMS key ARN** (for token encryption):
+```bash
+AWS_PROFILE=<profile> aws kms list-keys --region us-east-1 \
+  --query 'Keys[*].KeyId' --output text | tr '\t' '\n' | \
+  while read k; do
+    AWS_PROFILE=<profile> aws kms describe-key --key-id "$k" \
+      --region us-east-1 \
+      --query 'KeyMetadata.{Id:KeyId,Desc:Description}' \
+      --output text 2>/dev/null
+  done | grep -i token
+```
+
+#### Example (ai3-mvp on sbalswa)
+
+```bash
+AWS_PROFILE=burner2 npx ts-node src/app-framework-cli.ts device-flow-auth \
+  --client-id Iv23li6ndiRoICMS3xab \
+  --user-tokens-table the-app-framework-test-stack-WebhookIngestionUserTokensTable55E7B5B8-GC4E0APDP7QC \
+  --kms-key-arn arn:aws:kms:us-east-1:361116840407:key/3f894217-4b23-469e-8741-a615b090d5e2
+```
+
+## Token Lifecycle
+
+| Token | Lifetime | Auto-Refresh |
+|-------|----------|-------------|
+| Access token (`ghu_`) | 8 hours | Yes — authorizeUser module refreshes automatically |
+| Refresh token (`ghr_`) | 6 months (rotated on each use) | Automatic when access token expires |
+
+## When Re-Authorization is Needed
+
+- First time a user interacts with the bot
+- Refresh token expires (6 months of inactivity)
+- User revokes the app (GitHub Settings → Applications → Revoke)
+- KMS key is rotated or deleted (existing encrypted tokens can't be decrypted)
+- DynamoDB UserTokens table is recreated (disaster recovery)
+
+## Verifying a User's Token
+
+```bash
+AWS_PROFILE=<profile> aws dynamodb get-item \
+  --table-name <USER_TOKENS_TABLE> \
+  --key '{"GitHubUserId":{"N":"<USER_ID>"}}' \
+  --region us-east-1 \
+  --query 'Item.{Login:Login.S,Expiry:TokenExpiry.S,LastUsed:LastUsed.S}'
+```
+
+## Revoking a User's Token
+
+Delete from DynamoDB (the user will be prompted to re-authorize next time):
+
+```bash
+AWS_PROFILE=<profile> aws dynamodb delete-item \
+  --table-name <USER_TOKENS_TABLE> \
+  --key '{"GitHubUserId":{"N":"<USER_ID>"}}' \
+  --region us-east-1
+```
+
+The user can also revoke from GitHub: Settings → Applications → Authorized GitHub Apps → ai3-mvp → Revoke.

--- a/src/packages/app-framework-ops-tools/src/app-framework-cli.ts
+++ b/src/packages/app-framework-ops-tools/src/app-framework-cli.ts
@@ -77,4 +77,20 @@ program
       process.exit(1);
     }
   });
+// subcommand - device-flow-auth
+program
+  .command('device-flow-auth')
+  .description('Authorize a GitHub user via OAuth Device Flow and store token in DynamoDB')
+  .requiredOption('--client-id <clientId>', 'GitHub App Client ID')
+  .requiredOption('--user-tokens-table <tableName>', 'DynamoDB UserTokens table name')
+  .option('--kms-key-arn <keyArn>', 'KMS key ARN for token encryption')
+  .action(async (options) => {
+    try {
+      const { deviceFlowAuth } = await import('./deviceFlowAuth');
+      await deviceFlowAuth(options.clientId, options.userTokensTable, options.kmsKeyArn);
+    } catch (error) {
+      console.error('Device flow auth failed:', error);
+      process.exit(1);
+    }
+  });
 program.parse(process.argv);

--- a/src/packages/app-framework-ops-tools/src/deviceFlowAuth.ts
+++ b/src/packages/app-framework-ops-tools/src/deviceFlowAuth.ts
@@ -1,0 +1,150 @@
+import { DynamoDBClient, PutItemCommand } from '@aws-sdk/client-dynamodb';
+import { KMSClient, EncryptCommand } from '@aws-sdk/client-kms';
+
+export async function deviceFlowAuth(
+  clientId: string,
+  userTokensTable: string,
+  kmsKeyArn?: string,
+): Promise<void> {
+  // Step 1: Request device code
+  const codeResp = await fetch('https://github.com/login/device/code', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    body: JSON.stringify({ client_id: clientId }),
+  });
+  const codeData = (await codeResp.json()) as {
+    device_code: string;
+    user_code: string;
+    verification_uri: string;
+    expires_in: number;
+    interval: number;
+  };
+
+  console.log('');
+  console.log('====================================');
+  console.log(`  Go to: ${codeData.verification_uri}`);
+  console.log(`  Enter code: ${codeData.user_code}`);
+  console.log('====================================');
+  console.log('');
+  console.log('Waiting for authorization...');
+
+  // Step 2: Poll for token
+  const interval = (codeData.interval || 5) * 1000;
+  const expires = Date.now() + codeData.expires_in * 1000;
+
+  while (Date.now() < expires) {
+    await new Promise((r) => setTimeout(r, interval));
+
+    const tokenResp = await fetch(
+      'https://github.com/login/oauth/access_token',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+        body: JSON.stringify({
+          client_id: clientId,
+          device_code: codeData.device_code,
+          grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+        }),
+      },
+    );
+    const tokenData = (await tokenResp.json()) as Record<string, unknown>;
+
+    if (tokenData.access_token) {
+      const accessToken = tokenData.access_token as string;
+      const refreshToken = (tokenData.refresh_token as string) || '';
+      const expiresIn = (tokenData.expires_in as number) || 28800;
+      const scope = (tokenData.scope as string) || '';
+
+      // Step 3: Get user info
+      const userResp = await fetch('https://api.github.com/user', {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          Accept: 'application/vnd.github+json',
+        },
+      });
+      const userData = (await userResp.json()) as {
+        id: number;
+        login: string;
+      };
+
+      // Step 4: Optionally encrypt tokens with KMS
+      let storedAccessToken = accessToken;
+      let storedRefreshToken = refreshToken;
+
+      if (kmsKeyArn) {
+        const kms = new KMSClient({});
+        const encAccess = await kms.send(
+          new EncryptCommand({
+            KeyId: kmsKeyArn,
+            Plaintext: Buffer.from(accessToken),
+          }),
+        );
+        storedAccessToken = Buffer.from(encAccess.CiphertextBlob!).toString(
+          'base64',
+        );
+
+        if (refreshToken) {
+          const encRefresh = await kms.send(
+            new EncryptCommand({
+              KeyId: kmsKeyArn,
+              Plaintext: Buffer.from(refreshToken),
+            }),
+          );
+          storedRefreshToken = Buffer.from(
+            encRefresh.CiphertextBlob!,
+          ).toString('base64');
+        }
+        console.log('Tokens encrypted with KMS key');
+      }
+
+      // Step 5: Store in DynamoDB
+      const ddb = new DynamoDBClient({});
+      const expiry = new Date(Date.now() + expiresIn * 1000).toISOString();
+
+      await ddb.send(
+        new PutItemCommand({
+          TableName: userTokensTable,
+          Item: {
+            GitHubUserId: { N: String(userData.id) },
+            Login: { S: userData.login },
+            EncryptedAccessToken: { S: storedAccessToken },
+            EncryptedRefreshToken: { S: storedRefreshToken },
+            TokenExpiry: { S: expiry },
+            Scopes: { S: scope },
+            LastUsed: { S: new Date().toISOString() },
+          },
+        }),
+      );
+
+      console.log('');
+      console.log(`Authorized: ${userData.login} (ID: ${userData.id})`);
+      console.log(`Token expires: ${expiry}`);
+      console.log(`Stored in table: ${userTokensTable}`);
+      return;
+    }
+
+    if (tokenData.error === 'authorization_pending') {
+      process.stdout.write('.');
+      continue;
+    }
+
+    if (tokenData.error === 'slow_down') {
+      await new Promise((r) => setTimeout(r, 5000));
+      continue;
+    }
+
+    if (tokenData.error === 'expired_token') {
+      console.error('Authorization expired. Please try again.');
+      process.exit(1);
+    }
+
+    console.error(`Error: ${tokenData.error} - ${tokenData.error_description}`);
+    process.exit(1);
+  }
+
+  console.error('Timed out waiting for authorization.');
+  process.exit(1);
+}


### PR DESCRIPTION
## Issue
Closes #8

## Changes
New `device-flow-auth` command in ops-tools CLI:

```bash
app-framework-for-github-apps-on-aws-ops-tools device-flow-auth \
  --client-id Iv23li6ndiRoICMS3xab \
  --user-tokens-table <table-name> \
  --kms-key-arn <optional-key-arn>
```

Flow:
1. Requests device code from GitHub
2. Displays URL + code for user to authorize
3. Polls until authorized (handles slow_down, expired_token)
4. Fetches user profile
5. Optionally encrypts tokens with KMS
6. Stores in DynamoDB UserTokens table

## Test plan
- [x] TypeScript compiles (no new errors)
- [ ] Manual test: run command, authorize, verify token stored

🤖 Generated with [Claude Code](https://claude.com/claude-code)