### PR TITLE
feat: CI Check Express workflow with Step Functions (#10)

### DIFF
--- a/docs/runbooks/monitoring.md
+++ b/docs/runbooks/monitoring.md
@@ -1,0 +1,147 @@
+# Monitoring Runbook
+
+## Dashboard
+
+**URL:** https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#dashboards/dashboard/ai3-mvp-platform
+
+Shows: Events by handler, commands executed, auth results, errors, DLQ depth, API Gateway errors, alarms, health check, Step Functions executions.
+
+## Alarms
+
+| Alarm | What it means |
+|-------|---------------|
+| `ai3-mvp-webhook-oversized-payload` | API Gateway returned 4XX (possible >10MB payload) |
+| `ai3-mvp-dlq-not-empty` | A handler Lambda crashed — event in dead letter queue |
+
+## Looking Up a Job by ID
+
+When the bot replies `CI Check started (Job: <job-id>)`, use that ID to trace the full execution.
+
+### Find the job in DynamoDB
+
+```bash
+AWS_PROFILE=burner2 aws dynamodb get-item \
+  --table-name <jobs-table> \
+  --key "{\"JobId\":{\"S\":\"<job-id>\"}}" \
+  --region us-east-1
+```
+
+### Find the execution in Step Functions logs
+
+```bash
+AWS_PROFILE=burner2 aws logs filter-log-events \
+  --log-group-name the-app-framework-test-stack-WebhookIngestionCICheckWorkflowExecutionLogs0AFE04E5-QzYqW03zfOme \
+  --start-time $(date -d '8 hours ago' +%s000) \
+  --region us-east-1 \
+  --filter-pattern "<job-id>" \
+  --query 'events[*].message' --output text
+```
+
+### Find the Lambda invocations for that job
+
+```bash
+AWS_PROFILE=burner2 aws logs filter-log-events \
+  --log-group-name /aws/lambda/the-app-framework-test-st-WebhookIngestionCheckRun-CzVaxaCyNic7 \
+  --start-time $(date -d '8 hours ago' +%s000) \
+  --region us-east-1 \
+  --filter-pattern "<job-id>" \
+  --query 'events[*].message' --output text
+```
+
+## Viewing Step Functions Executions
+
+### Summary — successes and failures only
+
+```bash
+AWS_PROFILE=burner2 aws logs filter-log-events \
+  --log-group-name the-app-framework-test-stack-WebhookIngestionCICheckWorkflowExecutionLogs0AFE04E5-QzYqW03zfOme \
+  --start-time $(date -d '8 hours ago' +%s000) \
+  --region us-east-1 \
+  --filter-pattern '{ $.type = "ExecutionSucceeded" || $.type = "ExecutionFailed" }' \
+  --query 'events[*].message' --output text
+```
+
+### All state transitions (readable)
+
+```bash
+AWS_PROFILE=burner2 aws logs tail \
+  the-app-framework-test-stack-WebhookIngestionCICheckWorkflowExecutionLogs0AFE04E5-QzYqW03zfOme \
+  --since 8h --region us-east-1 \
+  | python3 -c "
+import sys, json
+for line in sys.stdin:
+    parts = line.strip().split(' ', 2)
+    if len(parts) < 3: continue
+    try:
+        d = json.loads(parts[2])
+        t = d.get('type','')
+        n = d.get('details',{}).get('name','')
+        if t: print(f'{t:30s} {n}')
+    except: pass
+"
+```
+
+### CheckRunStep Lambda logs (create/complete)
+
+```bash
+AWS_PROFILE=burner2 aws logs filter-log-events \
+  --log-group-name /aws/lambda/the-app-framework-test-st-WebhookIngestionCheckRun-CzVaxaCyNic7 \
+  --start-time $(date -d '8 hours ago' +%s000) \
+  --region us-east-1 \
+  --filter-pattern 'INFO' \
+  --query 'events[*].message' --output text
+```
+
+## Viewing Webhook Handler Logs
+
+### Comment handler (processes @ai3-mvp commands)
+
+```bash
+AWS_PROFILE=burner2 aws logs tail \
+  /aws/lambda/the-app-framework-test-st-WebhookIngestionCommentH-3XMAqXoApKDe \
+  --since 1h --region us-east-1
+```
+
+### Webhook receiver (signature verification, dispatch)
+
+```bash
+AWS_PROFILE=burner2 aws logs tail \
+  /aws/lambda/the-app-framework-test-st-WebhookIngestionReceiver-EwwytlIJmkXW \
+  --since 1h --region us-east-1
+```
+
+### Health check (runs every 15 min)
+
+```bash
+AWS_PROFILE=burner2 aws logs tail \
+  /aws/lambda/the-app-framework-test-st-WebhookIngestionHealthCh-Yoi782ERJhEO \
+  --since 1h --region us-east-1
+```
+
+## Custom Metrics
+
+Namespace: `GitHubAppPlatform`
+
+| Metric | Dimensions | Meaning |
+|--------|-----------|---------|
+| `EventProcessed` | AppId, EventType, HandlerName, OrgName | An event was handled |
+| `CommandExecuted` | AppId, Command, HandlerName, OrgName | A bot command ran |
+| `AuthSuccess` | AppId, HandlerName, OrgName | User authorized successfully |
+| `AuthFailed` | AppId, HandlerName, OrgName | Authorization denied |
+| `ErrorOccurred` | AppId, HandlerName, OrgName | Handler error (also goes to DLQ) |
+| `HealthCheckSuccess` | AppId, CheckType | Health check pass (1) or fail (0) |
+
+Browse in console: CloudWatch → Metrics → All metrics → `GitHubAppPlatform`
+
+## DLQ Investigation
+
+When the DLQ alarm fires:
+
+```bash
+# See what's in the DLQ
+AWS_PROFILE=burner2 aws logs tail \
+  /aws/lambda/the-app-framework-test-st-WebhookIngestionAlertha-<id> \
+  --since 1h --region us-east-1
+```
+
+The alert handler logs the full failed event body including the delivery ID, which you can use to redrive (see `docs/runbooks/redrive-events.md`).

--- a/src/packages/app-framework/src/webhook/handlers/commands/check.ts
+++ b/src/packages/app-framework/src/webhook/handlers/commands/check.ts
@@ -1,0 +1,41 @@
+import { CommandContext } from './types';
+import { postComment } from '../../orchestration/reportComment';
+import { startExecution } from '../../orchestration/startExecution';
+
+export async function handleCheck(ctx: CommandContext): Promise<void> {
+  const stateMachineArn = process.env.CI_CHECK_STATE_MACHINE_ARN;
+  if (!stateMachineArn) {
+    await postComment({
+      token: ctx.token,
+      owner: ctx.owner,
+      repo: ctx.repo,
+      issueNumber: ctx.issueNumber,
+      body: `@${ctx.sender} CI Check workflow is not configured.`,
+    });
+    return;
+  }
+
+  // For PRs, we need the head SHA. For now use a placeholder.
+  // In production, this would come from the PR event payload.
+  const headSha = ctx.args || 'HEAD';
+
+  const result = await startExecution({
+    stateMachineArn,
+    input: {
+      token: ctx.token,
+      owner: ctx.owner,
+      repo: ctx.repo,
+      headSha,
+    },
+    userId: 0,
+    repoFullName: `${ctx.owner}/${ctx.repo}`,
+  });
+
+  await postComment({
+    token: ctx.token,
+    owner: ctx.owner,
+    repo: ctx.repo,
+    issueNumber: ctx.issueNumber,
+    body: `@${ctx.sender} CI Check started (Job: ${result.jobId}). Check the Checks tab for progress.`,
+  });
+}

--- a/src/packages/app-framework/src/webhook/handlers/commands/help.ts
+++ b/src/packages/app-framework/src/webhook/handlers/commands/help.ts
@@ -4,6 +4,7 @@ import { postComment } from '../../orchestration/reportComment';
 const AVAILABLE_COMMANDS = [
   '`help` - List available commands',
   '`echo <text>` - Echo back text',
+  '`check [sha]` - Run CI check (creates GitHub Check Run)',
   '`status` - Show running jobs (coming soon)',
   '`deploy <env>` - Deploy to environment (coming soon)',
 ];

--- a/src/packages/app-framework/src/webhook/handlers/commands/index.ts
+++ b/src/packages/app-framework/src/webhook/handlers/commands/index.ts
@@ -1,3 +1,4 @@
+import { handleCheck } from './check';
 import { handleEcho } from './echo';
 import { handleHelp } from './help';
 import { CommandHandler } from './types';
@@ -7,6 +8,7 @@ export { CommandContext, CommandHandler } from './types';
 const commands: Record<string, CommandHandler> = {
   help: handleHelp,
   echo: handleEcho,
+  check: handleCheck,
 };
 
 export function getCommandHandler(

--- a/src/packages/app-framework/src/webhook/handlers/commentHandler.ts
+++ b/src/packages/app-framework/src/webhook/handlers/commentHandler.ts
@@ -16,6 +16,7 @@ export interface CommentHandlerProps {
   readonly installationTokenLambdaArn: string;
   readonly tokenEncryptionKeyArn?: string;
   readonly jobsTableName?: string;
+  readonly ciCheckStateMachineArn?: string;
 }
 
 export class CommentHandler extends Construct {
@@ -39,6 +40,7 @@ export class CommentHandler extends Construct {
         NODE_ID: props.nodeId,
         INSTALLATION_TOKEN_FUNCTION_NAME: props.installationTokenFunctionName,
         JOBS_TABLE_NAME: props.jobsTableName || '',
+        CI_CHECK_STATE_MACHINE_ARN: props.ciCheckStateMachineArn || '',
         ...(props.tokenEncryptionKeyArn && {
           TOKEN_ENCRYPTION_KEY_ARN: props.tokenEncryptionKeyArn,
         }),

--- a/src/packages/app-framework/src/webhook/index.ts
+++ b/src/packages/app-framework/src/webhook/index.ts
@@ -540,6 +540,16 @@ export class WebhookIngestion extends Construct {
         width: 8,
         height: 6,
       }),
+      new GraphWidget({
+        title: 'Step Functions Executions',
+        left: [
+          ciCheckWorkflow.stateMachine.metricStarted({ period: Duration.minutes(5), label: 'Started' }),
+          ciCheckWorkflow.stateMachine.metricSucceeded({ period: Duration.minutes(5), label: 'Succeeded' }),
+          ciCheckWorkflow.stateMachine.metricFailed({ period: Duration.minutes(5), label: 'Failed' }),
+        ],
+        width: 8,
+        height: 6,
+      }),
     );
 
     if (props.appId && props.appTokenLambdaArn) {

--- a/src/packages/app-framework/src/webhook/index.ts
+++ b/src/packages/app-framework/src/webhook/index.ts
@@ -42,6 +42,8 @@ import { StubHandler } from './handlers/stubHandler';
 import { HealthCheck } from './healthCheck';
 import { JobsTable } from './orchestration/jobsTable';
 import { WebhookReceiver } from './receiver/webhookReceiver';
+import { CheckRunStep } from './workflows/checkRunStep';
+import { CICheckWorkflow } from './workflows/ciCheckWorkflow';
 
 export interface WebhookIngestionProps {
   readonly webhookSecretArn: string;
@@ -233,6 +235,11 @@ export class WebhookIngestion extends Construct {
     const jobs = new JobsTable(this, 'Jobs');
     this.jobsTable = jobs.table;
 
+    const checkRunStep = new CheckRunStep(this, 'CheckRunStep');
+    const ciCheckWorkflow = new CICheckWorkflow(this, 'CICheckWorkflow', {
+      checkRunStepFunction: checkRunStep.lambdaHandler,
+    });
+
     const alert = new AlertHandler(this, 'Alert');
 
     const stub = new StubHandler(this, 'StubHandler', { jobsTableName: this.jobsTable?.tableName });
@@ -257,10 +264,12 @@ export class WebhookIngestion extends Construct {
         installationTokenLambdaArn: props.installationTokenLambdaArn || '',
         tokenEncryptionKeyArn: this.userTokensTable.encryptionKey?.keyArn,
         jobsTableName: this.jobsTable?.tableName || '',
+        ciCheckStateMachineArn: ciCheckWorkflow.stateMachine.stateMachineArn,
       });
 
       this.userTokensTable.grantReadWriteData(comment.lambdaHandler);
       this.jobsTable?.grantReadWriteData(comment.lambdaHandler);
+      ciCheckWorkflow.stateMachine.grantStartExecution(comment.lambdaHandler);
       this.userTokensTable.encryptionKey?.grantEncryptDecrypt(
         comment.lambdaHandler,
       );

--- a/src/packages/app-framework/src/webhook/utils/idempotency.ts
+++ b/src/packages/app-framework/src/webhook/utils/idempotency.ts
@@ -21,7 +21,7 @@ export async function isAlreadyProcessed(
       new PutItemCommand({
         TableName: tableName,
         Item: {
-          JobId: { S: `delivery:${deliveryId}` },
+          JobId: { S: `delivery:${handlerName}:${deliveryId}` },
           DeliveryId: { S: deliveryId },
           HandlerName: { S: handlerName },
           ProcessedAt: { S: new Date().toISOString() },

--- a/src/packages/app-framework/src/webhook/workflows/checkRunStep.handler.ts
+++ b/src/packages/app-framework/src/webhook/workflows/checkRunStep.handler.ts
@@ -1,0 +1,69 @@
+export const handler = async (event: {
+  action: 'create' | 'complete';
+  token: string;
+  owner: string;
+  repo: string;
+  headSha: string;
+  checkRunId?: number;
+  jobId: string;
+}): Promise<{ checkRunId: number; jobId: string }> => {
+  if (event.action === 'create') {
+    const resp = await fetch(
+      `https://api.github.com/repos/${event.owner}/${event.repo}/check-runs`,
+      {
+        method: 'POST',
+        // prettier-ignore
+        headers: {
+          'Authorization': `Bearer ${event.token}`,
+          'Accept': 'application/vnd.github+json',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          name: 'ai3-mvp / CI Check',
+          head_sha: event.headSha,
+          status: 'in_progress',
+          started_at: new Date().toISOString(),
+        }),
+      },
+    );
+    if (!resp.ok) {
+      const text = await resp.text();
+      throw new Error(`Failed to create check run: ${resp.status} ${text}`);
+    }
+    const data = (await resp.json()) as { id: number };
+    console.log('Check run created', { checkRunId: data.id, jobId: event.jobId });
+    return { checkRunId: data.id, jobId: event.jobId };
+  }
+
+  if (event.action === 'complete') {
+    const resp = await fetch(
+      `https://api.github.com/repos/${event.owner}/${event.repo}/check-runs/${event.checkRunId}`,
+      {
+        method: 'PATCH',
+        // prettier-ignore
+        headers: {
+          'Authorization': `Bearer ${event.token}`,
+          'Accept': 'application/vnd.github+json',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          status: 'completed',
+          conclusion: 'success',
+          completed_at: new Date().toISOString(),
+          output: {
+            title: 'CI Check Passed',
+            summary: 'All checks completed successfully.',
+          },
+        }),
+      },
+    );
+    if (!resp.ok) {
+      const text = await resp.text();
+      throw new Error(`Failed to complete check run: ${resp.status} ${text}`);
+    }
+    console.log('Check run completed', { checkRunId: event.checkRunId, jobId: event.jobId });
+    return { checkRunId: event.checkRunId!, jobId: event.jobId };
+  }
+
+  throw new Error(`Unknown action: ${event.action}`);
+};

--- a/src/packages/app-framework/src/webhook/workflows/checkRunStep.ts
+++ b/src/packages/app-framework/src/webhook/workflows/checkRunStep.ts
@@ -1,0 +1,18 @@
+import { Duration } from 'aws-cdk-lib';
+import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
+import { Construct } from 'constructs';
+import { LAMBDA_DEFAULTS } from '../../lambdaDefaults';
+
+export class CheckRunStep extends Construct {
+  readonly lambdaHandler: NodejsFunction;
+
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+    this.lambdaHandler = new NodejsFunction(this, 'handler', {
+      ...LAMBDA_DEFAULTS,
+      description: 'Step Functions step: create/complete GitHub Check Run',
+      memorySize: 256,
+      timeout: Duration.seconds(30),
+    });
+  }
+}

--- a/src/packages/app-framework/src/webhook/workflows/ciCheckWorkflow.ts
+++ b/src/packages/app-framework/src/webhook/workflows/ciCheckWorkflow.ts
@@ -1,7 +1,9 @@
-import { Duration } from 'aws-cdk-lib';
+import { Duration, RemovalPolicy } from 'aws-cdk-lib';
 import { IFunction } from 'aws-cdk-lib/aws-lambda';
+import { LogGroup, RetentionDays } from 'aws-cdk-lib/aws-logs';
 import {
   DefinitionBody,
+  LogLevel,
   StateMachine,
   StateMachineType,
   Wait,
@@ -65,10 +67,20 @@ export class CICheckWorkflow extends Construct {
       .next(simulateCI)
       .next(completeCheckRun);
 
+    const logGroup = new LogGroup(this, 'ExecutionLogs', {
+      retention: RetentionDays.ONE_MONTH,
+      removalPolicy: RemovalPolicy.DESTROY,
+    });
+
     this.stateMachine = new StateMachine(this, 'StateMachine', {
       definitionBody: DefinitionBody.fromChainable(definition),
       stateMachineType: StateMachineType.EXPRESS,
       timeout: Duration.minutes(5),
+      logs: {
+        destination: logGroup,
+        level: LogLevel.ALL,
+        includeExecutionData: true,
+      },
     });
   }
 }

--- a/src/packages/app-framework/src/webhook/workflows/ciCheckWorkflow.ts
+++ b/src/packages/app-framework/src/webhook/workflows/ciCheckWorkflow.ts
@@ -1,0 +1,74 @@
+import { Duration } from 'aws-cdk-lib';
+import { IFunction } from 'aws-cdk-lib/aws-lambda';
+import {
+  DefinitionBody,
+  StateMachine,
+  StateMachineType,
+  Wait,
+  WaitTime,
+} from 'aws-cdk-lib/aws-stepfunctions';
+import { LambdaInvoke } from 'aws-cdk-lib/aws-stepfunctions-tasks';
+import { Construct } from 'constructs';
+
+export interface CICheckWorkflowProps {
+  readonly checkRunStepFunction: IFunction;
+}
+
+export class CICheckWorkflow extends Construct {
+  readonly stateMachine: StateMachine;
+
+  constructor(scope: Construct, id: string, props: CICheckWorkflowProps) {
+    super(scope, id);
+
+    const createCheckRun = new LambdaInvoke(this, 'CreateCheckRun', {
+      lambdaFunction: props.checkRunStepFunction,
+      payload: {
+        type: 1,
+        value: {
+          'action': 'create',
+          'token.$': '$.token',
+          'owner.$': '$.owner',
+          'repo.$': '$.repo',
+          'headSha.$': '$.headSha',
+          'jobId.$': '$.jobId',
+        },
+      },
+      resultPath: '$.createResult',
+      resultSelector: {
+        'checkRunId.$': '$.Payload.checkRunId',
+        'jobId.$': '$.Payload.jobId',
+      },
+    });
+
+    const simulateCI = new Wait(this, 'SimulateCI', {
+      time: WaitTime.duration(Duration.seconds(5)),
+      comment: 'Simulated CI work (replace with real build/test steps)',
+    });
+
+    const completeCheckRun = new LambdaInvoke(this, 'CompleteCheckRun', {
+      lambdaFunction: props.checkRunStepFunction,
+      payload: {
+        type: 1,
+        value: {
+          'action': 'complete',
+          'token.$': '$.token',
+          'owner.$': '$.owner',
+          'repo.$': '$.repo',
+          'checkRunId.$': '$.createResult.checkRunId',
+          'jobId.$': '$.createResult.jobId',
+        },
+      },
+      resultPath: '$.completeResult',
+    });
+
+    const definition = createCheckRun
+      .next(simulateCI)
+      .next(completeCheckRun);
+
+    this.stateMachine = new StateMachine(this, 'StateMachine', {
+      definitionBody: DefinitionBody.fromChainable(definition),
+      stateMachineType: StateMachineType.EXPRESS,
+      timeout: Duration.minutes(5),
+    });
+  }
+}


### PR DESCRIPTION
## Issue
Closes #10 (partial - Express workflow only, Standard/long-running deferred)

## Changes
- Express Step Functions workflow: Create Check Run → Wait 5s → Complete Check Run
- `@ai3-mvp check [sha]` command triggers the workflow
- `checkRunStep` Lambda invoked by Step Functions for Check Run API calls
- CDK wiring: state machine + permissions + env vars

## Architecture
```
@ai3-mvp check abc123
  → Comment Handler → check command
    → startExecution (Express workflow)
      → Step 1: Create GitHub Check Run (in_progress)
      → Step 2: Wait 5s (simulated CI)
      → Step 3: Complete Check Run (success)
    → Posts 'CI Check started' comment
```

## Test plan
- [x] TypeScript compiles
- [ ] Deploy
- [ ] Test `@ai3-mvp check <sha>` on a PR
- [ ] Verify Check Run appears on the commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)