### PR TITLE
fix: disaster recovery runbook findings + PR templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/bugfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bugfix.md
@@ -1,0 +1,17 @@
+## Summary
+<!-- What bug does this fix? -->
+
+## Issue
+<!-- Closes #XX -->
+
+## Root Cause
+<!-- What was wrong and why -->
+
+## Fix
+<!-- What was changed to resolve it -->
+
+## Testing
+- [ ] Unit tests pass (`npx projen build`)
+- [ ] Deployed to test stack
+- [ ] Bug is no longer reproducible
+- [ ] No regressions: `@ai3-mvp help` still responds

--- a/.github/PULL_REQUEST_TEMPLATE/disaster-recovery-testing.md
+++ b/.github/PULL_REQUEST_TEMPLATE/disaster-recovery-testing.md
@@ -1,0 +1,35 @@
+## Disaster Recovery Test
+
+### Environment
+- **AWS Profile:** 
+- **Account ID:** 
+- **Region:** 
+
+### Runbook Steps Completed
+- [ ] 1. Prerequisites verified (Node >= 22, CDK, yarn, AWS CLI)
+- [ ] 2. CDK bootstrapped
+- [ ] 3. Dependencies installed and built
+- [ ] 4. Secrets created (webhook + OAuth client)
+- [ ] 5. Stack deployed
+- [ ] 6. Private key generated and imported
+- [ ] 7. GitHub App webhook URL/secret/callback updated
+- [ ] 8. OAuth re-authorized via device flow
+- [ ] 9. Verification passed
+
+### Verification Results
+- [ ] Health check Lambda passes (GET /app succeeds)
+- [ ] `@ai3-mvp help` replies on a PR
+- [ ] `@ai3-mvp check <sha>` creates a Check Run
+- [ ] Dashboard shows metrics
+- [ ] Webhook deliveries show 200 in GitHub App settings
+
+### Findings / Documentation Gaps
+<!-- List any issues found during recovery -->
+| # | Finding | Fix Applied? |
+|---|---------|-------------|
+| | | |
+
+### Runbook Accuracy
+- [ ] All steps were accurate and complete
+- [ ] No undocumented steps were needed
+- [ ] Order of operations was correct

--- a/.github/PULL_REQUEST_TEMPLATE/docs.md
+++ b/.github/PULL_REQUEST_TEMPLATE/docs.md
@@ -1,0 +1,11 @@
+## Summary
+<!-- What documentation was updated? -->
+
+## Changes
+<!-- List files changed and why -->
+
+## Verification
+- [ ] No broken links
+- [ ] Instructions are actionable (tested or reviewed)
+- [ ] Consistent with other docs
+- [ ] No hardcoded credentials/ARNs

--- a/.github/PULL_REQUEST_TEMPLATE/feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature.md
@@ -1,0 +1,30 @@
+## Summary
+<!-- Brief description of what this PR does -->
+
+## Issue
+<!-- Closes #XX -->
+
+## Changes
+<!-- List key changes -->
+
+## Testing
+- [ ] Unit tests pass (`npx projen build`)
+- [ ] TypeScript compiles (`npx tsc --noEmit`)
+- [ ] Deployed to test stack
+- [ ] E2E verified:
+  - [ ] `@ai3-mvp help` responds
+  - [ ] New feature works as described
+  - [ ] No regressions in existing features
+
+## Bot Commands Verified
+- [ ] `@ai3-mvp help` — lists commands
+- [ ] `@ai3-mvp echo <text>` — echoes back
+- [ ] `@ai3-mvp check <sha>` — creates Check Run
+- [ ] Health check passing (CloudWatch dashboard)
+- [ ] No DLQ messages
+
+## Documentation
+- [ ] ADR created (if architectural decision)
+- [ ] Runbook updated (if ops procedure changed)
+- [ ] QUICK_START.md updated (if user-facing change)
+- [ ] Help text updated (if new command)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,1 +1,12 @@
+<!-- 
+For specific PR types, use a template:
+- Feature: ?template=feature.md
+- Bug fix: ?template=bugfix.md  
+- Documentation: ?template=docs.md
+- Disaster Recovery Test: ?template=disaster-recovery-testing.md
+
+Append the query param to your PR creation URL, or use:
+gh pr create --template feature.md
+-->
+
 Fixes #

--- a/docs/runbooks/disaster-recovery-and-replication.md
+++ b/docs/runbooks/disaster-recovery-and-replication.md
@@ -27,10 +27,12 @@ If your AWS account is deleted or all resources are removed, here's how to recre
 AWS_PROFILE=<your-profile> aws sts get-caller-identity
 
 # Verify Node.js, CDK, yarn
-node --version   # >= 18
+node --version   # >= 22
 cdk --version
 yarn --version
 ```
+
+> **Note:** If your AWS account has changed, update your AWS CLI profile. The profile name may differ from the original deployment (e.g., `burner2` → `burner1`). Verify with `aws sts get-caller-identity` before proceeding.
 
 #### 2. Bootstrap CDK (if new account)
 
@@ -111,7 +113,30 @@ Go to `github.com/organizations/<org>/settings/apps/<app-name>`:
 - **Webhook secret**: Set to the value from Step 4
 - **Callback URL**: Set to `https://<api-gateway-id>.execute-api.<region>.amazonaws.com/prod/auth/callback`
 
-#### 8. Verify
+> **Future automation:** Updating webhook URL/secret requires browser access or App-authenticated API calls (JWT signed with the private key). A future ops-tools CLI command could automate this using the imported KMS key to sign the JWT.
+
+#### 8. Re-Authorize Users (Device Flow)
+
+Users must re-authorize since the UserTokens table is empty. Use the device flow CLI:
+
+```bash
+cd src/packages/app-framework-ops-tools
+AWS_PROFILE=<profile> npx ts-node src/app-framework-cli.ts device-flow-auth \
+  --client-id <GITHUB_CLIENT_ID> \
+  --user-tokens-table <USER_TOKENS_TABLE> \
+  --kms-key-arn <TOKEN_ENCRYPTION_KEY_ARN>
+```
+
+Find the KMS key:
+```bash
+AWS_PROFILE=<profile> aws kms list-keys --region <REGION> --query 'Keys[*].KeyId' --output text | tr '\t' '\n' | while read k; do
+  AWS_PROFILE=<profile> aws kms describe-key --key-id "$k" --region <REGION> --query 'KeyMetadata.{Id:KeyId,Desc:Description}' --output text 2>/dev/null
+done | grep -i token
+```
+
+> **Important:** This must be done BEFORE testing bot commands — without a valid OAuth token, the bot cannot respond even though the webhook pipeline is working.
+
+#### 9. Verify
 
 **Test webhook:**
 ```bash
@@ -125,9 +150,9 @@ Star/unstar a repo in the org. Check CloudWatch logs for the stub handler.
 **Test OAuth:**
 Run the device flow or visit the login URL in a browser.
 
-#### 9. Users Must Re-Authorize
+#### 10. Users Must Re-Authorize (Automatic)
 
-The UserTokens table is empty. Each user will need to click the OAuth authorization link again the next time they mention `@ai3-mvp`. The bot will prompt them automatically.
+The UserTokens table is empty. Any user who did NOT use the device flow in Step 8 will need to click the OAuth authorization link again the next time they mention `@ai3-mvp`. The bot will prompt them automatically.
 
 ---
 


### PR DESCRIPTION
## Context
Findings from exercising the disaster recovery runbook on a fresh AWS account (Issue #26).

## Changes
- **DR Runbook**: Fixed Node version (>=22), added AWS profile change note, reordered device flow before verification, added webhook automation future note
- **PR Templates**: Created 4 specialized templates (feature, bugfix, docs, disaster-recovery-testing)
- **Default template**: References specialized templates

## DR Findings Addressed
| # | Finding | Fix |
|---|---------|-----|
| 1 | AWS profile may change | Added note about verifying profile |
| 2 | Node version says >= 18 | Changed to >= 22 |
| 3 | Webhook config requires browser | Added future automation note + Issue #30 |
| 4 | Device flow must precede testing | Reordered steps |

## Related Issues
- #26 — Disaster recovery (validated ✅)
- #29 — GitHub Community Health Files (backlog)
- #30 — Automate webhook config via JWT (backlog)

🤖 Generated with [Claude Code](https://claude.com/claude-code)