### PR TITLE
fix: exclude acceptance tests from CI build

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -269,6 +269,7 @@ const theAppFrameworkOpsTools = new typescript.TypeScriptProject({
     jestConfig: {
       runner: "groups",
       verbose: true,
+      testPathIgnorePatterns: ["/node_modules/", ".*\\.accept\\.test\\.ts$"],
     },
   },
 });

--- a/src/packages/app-framework-ops-tools/package.json
+++ b/src/packages/app-framework-ops-tools/package.json
@@ -64,6 +64,10 @@
     "coverageProvider": "v8",
     "runner": "groups",
     "verbose": true,
+    "testPathIgnorePatterns": [
+      "/node_modules/",
+      ".*\\.accept\\.test\\.ts$"
+    ],
     "testMatch": [
       "<rootDir>/@(src|test)/**/*(*.)@(spec|test).ts?(x)",
       "<rootDir>/@(src|test)/**/__tests__/**/*.ts?(x)"
@@ -79,10 +83,8 @@
     ],
     "coverageDirectory": "coverage",
     "coveragePathIgnorePatterns": [
-      "/node_modules/"
-    ],
-    "testPathIgnorePatterns": [
-      "/node_modules/"
+      "/node_modules/",
+      ".*\\.accept\\.test\\.ts$"
     ],
     "watchPathIgnorePatterns": [
       "/node_modules/"


### PR DESCRIPTION
## Summary
- Add `testPathIgnorePatterns` with `.*\.accept\.test\.ts$` to the ops-tools package Jest config in `.projenrc.ts`
- This ensures `lerna run build` skips acceptance tests that require AWS credentials, fixing CI failures that block all PRs
- The root project's task already excluded these via CLI flag, but that flag wasn't applied when lerna invoked Jest through the package's own `package.json` config

## Test plan
- [x] `npx projen` regenerates `package.json` with the new pattern
- [x] `npx jest --passWithNoTests` in ops-tools passes (72 tests, 0 failures)
- [ ] CI build workflow passes without AWS credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)