### PR TITLE
fix: remove worktree submodule and gitignore .claude/worktrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ cdk.out
 __snapshots__
 classpath.json
 .remember
+.claude/worktrees/
 /test-reports/
 junit.xml
 /coverage/

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -102,6 +102,7 @@ export const project = new awscdk.AwsCdkConstructLibrary({
     "__snapshots__",
     "classpath.json",
     ".remember",
+    ".claude/worktrees/",
   ],
   eslint: true,
   eslintOptions: {


### PR DESCRIPTION
## Summary

- Removes `.claude/worktrees/expo` gitlink (mode 160000) that was accidentally committed in PR #64
- Adds `.claude/worktrees/` to `.gitignore` via `.projenrc.ts` to prevent recurrence

## Issue

Partial fix for #67

## Changes

- `.projenrc.ts`: added `.claude/worktrees/` to `gitignore` array
- `.gitignore`: regenerated by projen (now includes the rule)
- Removed submodule entry for `.claude/worktrees/expo`

## Testing

- [ ] `npx projen build` passes (no functional changes — gitignore only)
- [ ] Verify `.claude/worktrees/` no longer shows in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)