### PR TITLE
fix: coverage-ratchet sed patterns match only threshold lines

### DIFF
--- a/.github/workflows/coverage-ratchet.yml
+++ b/.github/workflows/coverage-ratchet.yml
@@ -79,10 +79,10 @@ jobs:
           NEW_FUNCS: ${{ steps.bump.outputs.funcs }}
           NEW_LINES: ${{ steps.bump.outputs.lines }}
         run: |
-          sed -i "s/statements: [0-9]*/statements: $NEW_STMTS/" .projenrc.ts
-          sed -i "s/branches: [0-9]*/branches: $NEW_BRANCHES/" .projenrc.ts
-          sed -i "s/functions: [0-9]*/functions: $NEW_FUNCS/" .projenrc.ts
-          sed -i "s/lines: [0-9]*/lines: $NEW_LINES/" .projenrc.ts
+          sed -i "s/statements: [0-9]\+,/statements: $NEW_STMTS,/" .projenrc.ts
+          sed -i "s/branches: [0-9]\+,/branches: $NEW_BRANCHES,/" .projenrc.ts
+          sed -i "s/functions: [0-9]\+,/functions: $NEW_FUNCS,/" .projenrc.ts
+          sed -i "s/lines: [0-9]\+,/lines: $NEW_LINES,/" .projenrc.ts
           npx projen
 
       - name: Create PR


### PR DESCRIPTION
## Summary

- Fixes greedy sed pattern in coverage-ratchet workflow that corrupted `.projenrc.ts`
- `branches: [0-9]*` matched the workflow trigger `branches: ["main"]` (zero digits match)
- Changed to `[0-9]\+,` (one-or-more digits + trailing comma) — only matches numeric thresholds

## Issue

Fixes #72

## Testing

Verified locally:
- Simulated ratchet bump (91→92, 80→82, 86→88, 91→93)
- Coverage thresholds updated correctly
- `push: { branches: ["main"] }` remains untouched
- `npx projen` succeeds after substitution

## Root Cause

| Pattern | Matches `branches: 80,` | Matches `branches: ["main"]` |
|---------|------------------------|------------------------------|
| `[0-9]*` (old) | Yes | Yes (zero digits) |
| `[0-9]\+,` (new) | Yes | No (no digits before non-comma) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)