### PR TITLE
fix: pin CI node-version to 22 (unblocks all builds)

### DIFF
--- a/.github/workflows/build-package-artifact.yml
+++ b/.github/workflows/build-package-artifact.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: lts/*
+          node-version: "22"
           registry-url: https://registry.npmjs.org
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: lts/*
+          node-version: "22"
       - name: Install dependencies
         run: yarn install --check-files
       - name: build

--- a/.github/workflows/centralized-release.yml
+++ b/.github/workflows/centralized-release.yml
@@ -132,7 +132,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: lts/*
+          node-version: "22"
           registry-url: https://registry.npmjs.org
       - name: Download artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: lts/*
+          node-version: "22"
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -93,6 +93,7 @@ export const addTestTargets = (subProject: Project) => {
 export const project = new awscdk.AwsCdkConstructLibrary({
   ...projectMetadata,
   jsiiVersion: "~5.9.0",
+  workflowNodeVersion: "22",
   projenrcTs: true,
   docgen: true,
   github: true,
@@ -548,7 +549,7 @@ if (centralizedRelease) {
           name: "Setup Node.js",
           uses: "actions/setup-node@v4",
           with: {
-            "node-version": "lts/*",
+            "node-version": "22",
             "registry-url": "https://registry.npmjs.org",
           },
         },
@@ -708,7 +709,7 @@ if (buildArtifactWorkflow) {
           name: "Setup Node.js",
           uses: "actions/setup-node@v4",
           with: {
-            "node-version": "lts/*",
+            "node-version": "22",
             "registry-url": "https://registry.npmjs.org",
           },
         },


### PR DESCRIPTION
## Summary

- Pins `workflowNodeVersion: "22"` in `.projenrc.ts` (regenerates all workflow files)
- Updates centralized-release custom steps from `lts/*` to `"22"`
- jsii 5.9 only supports `^22.0.0`; Node 24 became LTS recently, breaking all CI

## Issue

Fixes #74

## Changes

- `.projenrc.ts`: added `workflowNodeVersion: "22"`
- `.github/workflows/build.yml`: `lts/*` → `"22"` (projen-generated)
- `.github/workflows/build-package-artifact.yml`: same
- `.github/workflows/upgrade.yml`: same
- `.github/workflows/centralized-release.yml`: custom `lts/*` → `"22"`

## Testing

- [x] `npx projen build` passes locally (Node 24.14.0 local, but CI will now use 22)
- [x] All 4 workflow files regenerated correctly
- [x] No mutations (projen ran clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)