### PR TITLE
chore: pin GitHub Actions to SHA-versioned latest releases

### DIFF
--- a/.github/workflows/build-package-artifact.yml
+++ b/.github/workflows/build-package-artifact.yml
@@ -23,11 +23,11 @@ jobs:
       CI: "true"
     steps:
       - name: Checkout
-        uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
       - name: Setup Node.js
-        uses: "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0"
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: lts/*
           registry-url: https://registry.npmjs.org
@@ -49,7 +49,7 @@ jobs:
         run: cd dist && tar -xzf "${{ inputs.package_name }}.tgz" --strip-components=1
         working-directory: ${{ inputs.package_path }}
       - name: Upload artifact
-        uses: "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1"
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: ${{ inputs.package_name }}
           path: ${{ inputs.package_path }}/dist

--- a/.github/workflows/build-package-artifact.yml
+++ b/.github/workflows/build-package-artifact.yml
@@ -23,11 +23,11 @@ jobs:
       CI: "true"
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2"
         with:
           fetch-depth: 0
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        uses: "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0"
         with:
           node-version: lts/*
           registry-url: https://registry.npmjs.org
@@ -49,7 +49,7 @@ jobs:
         run: cd dist && tar -xzf "${{ inputs.package_name }}.tgz" --strip-components=1
         working-directory: ${{ inputs.package_path }}
       - name: Upload artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1"
         with:
           name: ${{ inputs.package_name }}
           path: ${{ inputs.package_path }}/dist

--- a/.github/workflows/build-package-artifact.yml
+++ b/.github/workflows/build-package-artifact.yml
@@ -23,11 +23,11 @@ jobs:
       CI: "true"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: lts/*
           registry-url: https://registry.npmjs.org
@@ -49,7 +49,7 @@ jobs:
         run: cd dist && tar -xzf "${{ inputs.package_name }}.tgz" --strip-components=1
         working-directory: ${{ inputs.package_path }}
       - name: Upload artifact
-        uses: actions/upload-artifact@v4.4.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: ${{ inputs.package_name }}
           path: ${{ inputs.package_path }}/dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,12 +16,12 @@ jobs:
       NODE_OPTIONS: --max-old-space-size=8192
     steps:
       - name: Checkout
-        uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Setup Node.js
-        uses: "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0"
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: lts/*
       - name: Install dependencies
@@ -36,7 +36,7 @@ jobs:
         working-directory: ./
       - name: Upload patch
         if: steps.self_mutation.outputs.self_mutation_happened
-        uses: "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1"
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: repo.patch
           path: repo.patch
@@ -55,13 +55,13 @@ jobs:
     if: always() && needs.build.outputs.self_mutation_happened && !(github.event.pull_request.head.repo.full_name != github.repository)
     steps:
       - name: Checkout
-        uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Download patch
-        uses: "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1"
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: repo.patch
           path: ${{ runner.temp }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,12 +16,12 @@ jobs:
       NODE_OPTIONS: --max-old-space-size=8192
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: lts/*
       - name: Install dependencies
@@ -36,7 +36,7 @@ jobs:
         working-directory: ./
       - name: Upload patch
         if: steps.self_mutation.outputs.self_mutation_happened
-        uses: actions/upload-artifact@v4.4.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: repo.patch
           path: repo.patch
@@ -55,13 +55,13 @@ jobs:
     if: always() && needs.build.outputs.self_mutation_happened && !(github.event.pull_request.head.repo.full_name != github.repository)
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Download patch
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: repo.patch
           path: ${{ runner.temp }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,12 +16,12 @@ jobs:
       NODE_OPTIONS: --max-old-space-size=8192
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2"
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        uses: "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0"
         with:
           node-version: lts/*
       - name: Install dependencies
@@ -36,7 +36,7 @@ jobs:
         working-directory: ./
       - name: Upload patch
         if: steps.self_mutation.outputs.self_mutation_happened
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1"
         with:
           name: repo.patch
           path: repo.patch
@@ -55,13 +55,13 @@ jobs:
     if: always() && needs.build.outputs.self_mutation_happened && !(github.event.pull_request.head.repo.full_name != github.repository)
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2"
         with:
           token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Download patch
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        uses: "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1"
         with:
           name: repo.patch
           path: ${{ runner.temp }}

--- a/.github/workflows/centralized-release.yml
+++ b/.github/workflows/centralized-release.yml
@@ -16,7 +16,7 @@ jobs:
       latest_commit: ${{ steps.git_remote.outputs.latest_commit }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
       - name: Set Git Identity
@@ -120,7 +120,7 @@ jobs:
     if: needs.setup_release.outputs.tag_exists != 'true' && needs.setup_release.outputs.latest_commit == github.sha
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
       - name: Set Git Identity
@@ -130,12 +130,12 @@ jobs:
       - name: Set package list
         run: echo "PACKAGES=@aws/app-framework-for-github-apps-on-aws-ops-tools @aws/app-framework-for-github-apps-on-aws-client @aws/app-framework-for-github-apps-on-aws-ssdk @aws/app-framework-for-github-apps-on-aws" >> $GITHUB_ENV
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: lts/*
           registry-url: https://registry.npmjs.org
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           merge-multiple: true
       - name: Extract package artifacts for publishing
@@ -195,9 +195,9 @@ jobs:
     if: needs.setup_release.outputs.tag_exists != 'true' && needs.setup_release.outputs.latest_commit == github.sha
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           merge-multiple: true
       - name: Create GitHub Release

--- a/.github/workflows/centralized-release.yml
+++ b/.github/workflows/centralized-release.yml
@@ -16,7 +16,7 @@ jobs:
       latest_commit: ${{ steps.git_remote.outputs.latest_commit }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2"
         with:
           fetch-depth: 0
       - name: Set Git Identity
@@ -120,7 +120,7 @@ jobs:
     if: needs.setup_release.outputs.tag_exists != 'true' && needs.setup_release.outputs.latest_commit == github.sha
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2"
         with:
           fetch-depth: 0
       - name: Set Git Identity
@@ -130,12 +130,12 @@ jobs:
       - name: Set package list
         run: echo "PACKAGES=@aws/app-framework-for-github-apps-on-aws-ops-tools @aws/app-framework-for-github-apps-on-aws-client @aws/app-framework-for-github-apps-on-aws-ssdk @aws/app-framework-for-github-apps-on-aws" >> $GITHUB_ENV
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        uses: "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0"
         with:
           node-version: lts/*
           registry-url: https://registry.npmjs.org
       - name: Download artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        uses: "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1"
         with:
           merge-multiple: true
       - name: Extract package artifacts for publishing
@@ -195,9 +195,9 @@ jobs:
     if: needs.setup_release.outputs.tag_exists != 'true' && needs.setup_release.outputs.latest_commit == github.sha
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2"
       - name: Download all artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        uses: "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1"
         with:
           merge-multiple: true
       - name: Create GitHub Release

--- a/.github/workflows/centralized-release.yml
+++ b/.github/workflows/centralized-release.yml
@@ -16,7 +16,7 @@ jobs:
       latest_commit: ${{ steps.git_remote.outputs.latest_commit }}
     steps:
       - name: Checkout
-        uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
       - name: Set Git Identity
@@ -120,7 +120,7 @@ jobs:
     if: needs.setup_release.outputs.tag_exists != 'true' && needs.setup_release.outputs.latest_commit == github.sha
     steps:
       - name: Checkout
-        uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
       - name: Set Git Identity
@@ -130,12 +130,12 @@ jobs:
       - name: Set package list
         run: echo "PACKAGES=@aws/app-framework-for-github-apps-on-aws-ops-tools @aws/app-framework-for-github-apps-on-aws-client @aws/app-framework-for-github-apps-on-aws-ssdk @aws/app-framework-for-github-apps-on-aws" >> $GITHUB_ENV
       - name: Setup Node.js
-        uses: "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0"
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: lts/*
           registry-url: https://registry.npmjs.org
       - name: Download artifacts
-        uses: "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1"
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           merge-multiple: true
       - name: Extract package artifacts for publishing
@@ -195,9 +195,9 @@ jobs:
     if: needs.setup_release.outputs.tag_exists != 'true' && needs.setup_release.outputs.latest_commit == github.sha
     steps:
       - name: Checkout
-        uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Download all artifacts
-        uses: "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1"
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           merge-multiple: true
       - name: Create GitHub Release

--- a/.github/workflows/pull-request-lint.yml
+++ b/.github/workflows/pull-request-lint.yml
@@ -19,7 +19,7 @@ jobs:
       pull-requests: write
     if: (github.event_name == 'pull_request' || github.event_name == 'pull_request_target')
     steps:
-      - uses: amannn/action-semantic-pull-request@v5.4.0
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/pull-request-lint.yml
+++ b/.github/workflows/pull-request-lint.yml
@@ -19,7 +19,7 @@ jobs:
       pull-requests: write
     if: (github.event_name == 'pull_request' || github.event_name == 'pull_request_target')
     steps:
-      - uses: "amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1"
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/pull-request-lint.yml
+++ b/.github/workflows/pull-request-lint.yml
@@ -19,7 +19,7 @@ jobs:
       pull-requests: write
     if: (github.event_name == 'pull_request' || github.event_name == 'pull_request_target')
     steps:
-      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50
+      - uses: "amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -15,9 +15,9 @@ jobs:
       patch_created: ${{ steps.create_patch.outputs.patch_created }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2"
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        uses: "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0"
         with:
           node-version: lts/*
       - name: Install dependencies
@@ -32,7 +32,7 @@ jobs:
         working-directory: ./
       - name: Upload patch
         if: steps.create_patch.outputs.patch_created
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1"
         with:
           name: repo.patch
           path: repo.patch
@@ -46,9 +46,9 @@ jobs:
     if: ${{ needs.upgrade.outputs.patch_created }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2"
       - name: Download patch
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        uses: "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1"
         with:
           name: repo.patch
           path: ${{ runner.temp }}
@@ -60,7 +60,7 @@ jobs:
           git config user.email "github-actions@github.com"
       - name: Create Pull Request
         id: create-pr
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
+        uses: "peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1"
         with:
           token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -15,9 +15,9 @@ jobs:
       patch_created: ${{ steps.create_patch.outputs.patch_created }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: lts/*
       - name: Install dependencies
@@ -32,7 +32,7 @@ jobs:
         working-directory: ./
       - name: Upload patch
         if: steps.create_patch.outputs.patch_created
-        uses: actions/upload-artifact@v4.4.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: repo.patch
           path: repo.patch
@@ -46,9 +46,9 @@ jobs:
     if: ${{ needs.upgrade.outputs.patch_created }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Download patch
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: repo.patch
           path: ${{ runner.temp }}
@@ -60,7 +60,7 @@ jobs:
           git config user.email "github-actions@github.com"
       - name: Create Pull Request
         id: create-pr
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
         with:
           token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -15,9 +15,9 @@ jobs:
       patch_created: ${{ steps.create_patch.outputs.patch_created }}
     steps:
       - name: Checkout
-        uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Setup Node.js
-        uses: "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0"
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: lts/*
       - name: Install dependencies
@@ -32,7 +32,7 @@ jobs:
         working-directory: ./
       - name: Upload patch
         if: steps.create_patch.outputs.patch_created
-        uses: "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1"
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: repo.patch
           path: repo.patch
@@ -46,9 +46,9 @@ jobs:
     if: ${{ needs.upgrade.outputs.patch_created }}
     steps:
       - name: Checkout
-        uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Download patch
-        uses: "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1"
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: repo.patch
           path: ${{ runner.temp }}
@@ -60,7 +60,7 @@ jobs:
           git config user.email "github-actions@github.com"
       - name: Create Pull Request
         id: create-pr
-        uses: "peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1"
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
         with:
           token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -130,6 +130,34 @@ export const project = new awscdk.AwsCdkConstructLibrary({
   // devDeps: [],             / Build dependencies for this module. /
   // packageName: undefined,  / The "name" in package.json. */
 });
+
+// Pin GitHub Actions to SHA-versioned releases
+// https://projen.io/docs/integrations/github/#actions-versions
+project.github?.actions.set(
+  "actions/checkout@v4",
+  "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd", // v6.0.2
+);
+project.github?.actions.set(
+  "actions/setup-node@v4",
+  "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e", // v6.4.0
+);
+project.github?.actions.set(
+  "actions/upload-artifact@v4.4.0",
+  "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a", // v7.0.1
+);
+project.github?.actions.set(
+  "actions/download-artifact@v4",
+  "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", // v8.0.1
+);
+project.github?.actions.set(
+  "peter-evans/create-pull-request@v6",
+  "peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1", // v8.1.1
+);
+project.github?.actions.set(
+  "amannn/action-semantic-pull-request@v5.4.0",
+  "amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50", // v6.1.1
+);
+
 if (project.github) {
   const buildWorkflow = project.github?.tryFindWorkflow("build");
   if (buildWorkflow && buildWorkflow.file) {

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -135,27 +135,27 @@ export const project = new awscdk.AwsCdkConstructLibrary({
 // https://projen.io/docs/integrations/github/#actions-versions
 project.github?.actions.set(
   "actions/checkout@v4",
-  "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2",
+  "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd", // v6.0.2
 );
 project.github?.actions.set(
   "actions/setup-node@v4",
-  "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0",
+  "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e", // v6.4.0
 );
 project.github?.actions.set(
   "actions/upload-artifact@v4.4.0",
-  "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1",
+  "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a", // v7.0.1
 );
 project.github?.actions.set(
   "actions/download-artifact@v4",
-  "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1",
+  "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", // v8.0.1
 );
 project.github?.actions.set(
   "peter-evans/create-pull-request@v6",
-  "peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1",
+  "peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1", // v8.1.1
 );
 project.github?.actions.set(
   "amannn/action-semantic-pull-request@v5.4.0",
-  "amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1",
+  "amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50", // v6.1.1
 );
 
 if (project.github) {

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -135,27 +135,27 @@ export const project = new awscdk.AwsCdkConstructLibrary({
 // https://projen.io/docs/integrations/github/#actions-versions
 project.github?.actions.set(
   "actions/checkout@v4",
-  "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd", // v6.0.2
+  "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2",
 );
 project.github?.actions.set(
   "actions/setup-node@v4",
-  "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e", // v6.4.0
+  "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0",
 );
 project.github?.actions.set(
   "actions/upload-artifact@v4.4.0",
-  "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a", // v7.0.1
+  "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1",
 );
 project.github?.actions.set(
   "actions/download-artifact@v4",
-  "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", // v8.0.1
+  "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1",
 );
 project.github?.actions.set(
   "peter-evans/create-pull-request@v6",
-  "peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1", // v8.1.1
+  "peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1",
 );
 project.github?.actions.set(
   "amannn/action-semantic-pull-request@v5.4.0",
-  "amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50", // v6.1.1
+  "amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1",
 );
 
 if (project.github) {


### PR DESCRIPTION
## Summary

- Pins all projen-generated GitHub Actions to immutable SHA references
- Uses `project.github?.actions.set()` API per [projen docs](https://projen.io/docs/integrations/github/#actions-versions)
- Upgrades action versions to latest stable releases

## Issue

Fixes #76

## Pinned Actions

| Action | Old | New |
|--------|-----|-----|
| actions/checkout | @v4 | @de0fac2e...  (v6.0.2) |
| actions/setup-node | @v4 | @48b55a01... (v6.4.0) |
| actions/upload-artifact | @v4.4.0 | @043fb46d... (v7.0.1) |
| actions/download-artifact | @v4 | @3e5f45b2... (v8.0.1) |
| peter-evans/create-pull-request | @v6 | @5f6978fa... (v8.1.1) |
| amannn/action-semantic-pull-request | @v5.4.0 | @48f25628... (v6.1.1) |

## Testing

- [x] `npx projen build` passes locally
- [x] All 6 workflow files regenerated with SHA pins
- [x] No mutations

## Note

This PR should be merged AFTER #75 (node version pin) since both modify workflow files. If #75 merges first, this PR will need a rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)