### PR TITLE
chore: codify agentic-first workflow — issue/worktree/agent/PR discipline

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/bugfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bugfix.md
@@ -10,6 +10,11 @@
 ## Fix
 <!-- What was changed to resolve it -->
 
+## Agentic Workflow
+- [ ] GitHub issue created/referenced before work began
+- [ ] Work done in dedicated worktree (not main)
+- [ ] No `.claude/worktrees/*` entries in staged files
+
 ## Testing
 - [ ] Unit tests pass (`npx projen build`)
 - [ ] Deployed to test stack

--- a/.github/PULL_REQUEST_TEMPLATE/docs.md
+++ b/.github/PULL_REQUEST_TEMPLATE/docs.md
@@ -4,6 +4,10 @@
 ## Changes
 <!-- List files changed and why -->
 
+## Agentic Workflow
+- [ ] GitHub issue created/referenced before work began
+- [ ] Work done in dedicated worktree (not main)
+
 ## Verification
 - [ ] No broken links
 - [ ] Instructions are actionable (tested or reviewed)

--- a/.github/PULL_REQUEST_TEMPLATE/feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature.md
@@ -7,6 +7,12 @@
 ## Changes
 <!-- List key changes -->
 
+## Agentic Workflow
+- [ ] GitHub issue created/referenced before work began
+- [ ] Work done in dedicated worktree (not main)
+- [ ] No `.claude/worktrees/*` entries in staged files
+- [ ] `npx projen` run and all generated files committed
+
 ## Testing
 - [ ] Unit tests pass (`npx projen build`)
 - [ ] TypeScript compiles (`npx tsc --noEmit`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,19 +5,22 @@
 **Every change follows this sequence. No exceptions.**
 
 ```
-main (clean) → Issue → Worktree → Build+Test → Push → Draft PR → CI Green → Review
+main (clean) → Issue → Worktree → Subagent → Build+Test → Push → Draft PR → CI Green → Ready → Notify
 ```
+
+The main context is the **orchestrator**. It coordinates, dispatches, and monitors. It does NOT write implementation code directly.
 
 1. **Main stays clean.** Never checkout a branch in the main worktree. Pull latest before starting.
 2. **Issue first.** Every non-trivial change starts with a GitHub issue. This is the async coordination signal — other agents and humans see intent before action.
-3. **Worktree isolated.** Create `git worktree add .claude/worktrees/<name> issues/<number>-<slug>` and work exclusively there.
-4. **Agent dispatched.** Subagents execute within the worktree: implement, test locally (`npx projen build`), commit specific files, push.
-5. **Draft PR.** Push creates a draft PR referencing the issue. PR title must use allowed types: `feat:`, `fix:`, or `chore:`.
-6. **CI green.** Wait for all workflow checks to pass. Fix failures in the same worktree.
-7. **Review.** Mark ready for review. Notify the operator.
-8. **Cleanup.** After merge: `git worktree remove` + `git branch -d` + `git pull origin main`.
+3. **Worktree created.** Create `git worktree add .claude/worktrees/<name> issues/<number>-<slug>` from the main worktree.
+4. **Subagent dispatched.** The main context dispatches a subagent to the worktree with clear instructions: what to implement, which files to touch, and what "done" looks like. The subagent implements, runs `npx projen build`, commits specific files, and pushes.
+5. **Draft PR.** The subagent (or main context) creates a draft PR referencing the issue. PR title must use allowed types: `feat:`, `fix:`, or `chore:`.
+6. **CI green.** Wait for all workflow checks to pass. If failures occur, dispatch the subagent again to fix in the same worktree.
+7. **Mark ready.** Once CI is green, mark the PR ready for review (`gh pr ready`).
+8. **Notify.** Inform the operator that the PR is ready for review with a link.
+9. **Cleanup.** After merge: `git worktree remove` + `git branch -d` + `git pull origin main`. Do this immediately.
 
-**If you're about to write code and haven't done steps 1-3, stop.**
+**If you're about to write code and haven't done steps 1-4, stop. You are the orchestrator, not the implementer.**
 
 ## Project
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,24 @@
 # AGENTS.md
 
+## Agentic Workflow: Issue-First, Worktree-Isolated, Agent-Dispatched
+
+**Every change follows this sequence. No exceptions.**
+
+```
+main (clean) → Issue → Worktree → Build+Test → Push → Draft PR → CI Green → Review
+```
+
+1. **Main stays clean.** Never checkout a branch in the main worktree. Pull latest before starting.
+2. **Issue first.** Every non-trivial change starts with a GitHub issue. This is the async coordination signal — other agents and humans see intent before action.
+3. **Worktree isolated.** Create `git worktree add .claude/worktrees/<name> issues/<number>-<slug>` and work exclusively there.
+4. **Agent dispatched.** Subagents execute within the worktree: implement, test locally (`npx projen build`), commit specific files, push.
+5. **Draft PR.** Push creates a draft PR referencing the issue. PR title must use allowed types: `feat:`, `fix:`, or `chore:`.
+6. **CI green.** Wait for all workflow checks to pass. Fix failures in the same worktree.
+7. **Review.** Mark ready for review. Notify the operator.
+8. **Cleanup.** After merge: `git worktree remove` + `git branch -d` + `git pull origin main`.
+
+**If you're about to write code and haven't done steps 1-3, stop.**
+
 ## Project
 
 Framework for GitHub Apps on AWS — a serverless bot platform that receives GitHub webhook events, authenticates users via OAuth, and orchestrates workflows via Step Functions.
@@ -51,6 +70,7 @@ cd src/packages/app-framework && npx jest --testPathPattern=<pattern>
 - **Verification before completion** — always deploy + E2E test before claiming done
 - **ADRs for decisions** — if it's a significant choice, document it in `adr/`
 - **Issues for backlog** — P0/P1/P2 with effort, details sufficient for agent pickup
+- **PR titles** — must use `feat:`, `fix:`, or `chore:` prefix (enforced by PR lint)
 
 ## Conventions
 
@@ -90,18 +110,47 @@ cd src/packages/app-framework && npx jest --testPathPattern=<pattern>
 
 The main worktree MUST stay on `main`. All branch work happens in dedicated worktrees.
 
+### Creating a worktree
+
+```bash
+# From the main worktree:
+git pull origin main
+git branch issues/<number>-<slug>
+git worktree add .claude/worktrees/<name> issues/<number>-<slug>
+cd .claude/worktrees/<name>
+```
+
 ### Rules
 1. **Main worktree = `main` only.** Never `git checkout <feature-branch>` in the main worktree.
-2. **Create worktrees for branch work:** `git worktree add .claude/worktrees/<name> <branch>`
-3. **Always `cd` to the worktree** before running git commands for that branch.
-4. **Never `git add -A`** — always add specific files. `-A` picks up nested worktrees as submodules.
-5. **Clean up after merge:** `git worktree remove .claude/worktrees/<name>` immediately.
-6. **Subagents with `isolation: "worktree"`** get automatic worktrees — don't create duplicates.
-7. **After subagent completes:** unlock + remove its worktree before doing manual branch work.
+2. **Always `cd` to the worktree** before running git commands for that branch.
+3. **Never `git add -A`** — always add specific files. `-A` picks up nested worktrees as submodules.
+4. **Subagents with `isolation: "worktree"`** get automatic worktrees — don't create duplicates.
+5. **After subagent completes:** unlock + remove its worktree before doing manual branch work.
+
+### Cleanup after merge
+
+```bash
+# From the main worktree:
+git worktree remove .claude/worktrees/<name>
+git branch -d issues/<number>-<slug>
+git pull origin main
+```
+
+Do this immediately after merge. Do NOT leave stale worktrees around.
+
+### Bulk cleanup (stale worktrees)
+
+```bash
+git worktree list                                    # identify non-main worktrees
+git -C .claude/worktrees/<name> status --short       # must be empty
+gh pr list --state merged --head <branch-name>       # PR must be merged
+git worktree remove .claude/worktrees/<name>         # remove
+git branch -d <branch-name>                          # delete local branch
+```
 
 ### Common failures this prevents
 - Dirty state leaking between branches
-- `.claude/worktrees/*` committed as git submodules
+- `.claude/worktrees/*` committed as git submodules (mode 160000)
 - `fatal: branch already used by worktree`
 - CWD confusion (running commands in wrong directory)
 - Stale changes persisting across checkout


### PR DESCRIPTION
## Summary

Establishes "Issue-First, Worktree-Isolated, Agent-Dispatched" as the mandatory workflow for all changes in this repository.

## Issue

Fixes #67

## Changes

- **AGENTS.md**: New top-level section defining the 8-step sequence that ALL work must follow
- **AGENTS.md**: Consolidated worktree discipline with explicit create/cleanup procedures
- **AGENTS.md**: Documented allowed PR title types (`feat:`, `fix:`, `chore:`)
- **PR templates**: Added "Agentic Workflow" checklist to feature, bugfix, and docs templates

## Agentic Workflow
- [x] GitHub issue created/referenced before work began (#67)
- [x] Work done in dedicated worktree (not main)
- [x] No `.claude/worktrees/*` entries in staged files
- [x] `npx projen` run and all generated files committed

## Verification
- [x] `npx projen build` passes (no code changes, docs only)
- [x] No broken links
- [x] Instructions are actionable
- [x] No hardcoded credentials/ARNs

🤖 Generated with [Claude Code](https://claude.com/claude-code)